### PR TITLE
Restrict admin area by email

### DIFF
--- a/lib/withAdminAccess.ts
+++ b/lib/withAdminAccess.ts
@@ -1,0 +1,24 @@
+import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import { parse } from 'cookie';
+
+export function withAdminAccess(gssp?: GetServerSideProps): GetServerSideProps {
+  return async (ctx: GetServerSidePropsContext) => {
+    const cookies = ctx.req.headers.cookie ? parse(ctx.req.headers.cookie) : {};
+    const userEmail = cookies['userEmail'];
+
+    if (userEmail !== 'kcc-kem@ya.ru') {
+      return {
+        redirect: {
+          destination: '/auth/login',
+          permanent: false,
+        },
+      };
+    }
+
+    if (gssp) {
+      return await gssp(ctx);
+    }
+
+    return { props: {} };
+  };
+}

--- a/pages/admin/agents.tsx
+++ b/pages/admin/agents.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import Head from 'next/head';
 import AdminLayout from '@/components/AdminLayout';
+import { withAdminAccess } from '@/lib/withAdminAccess';
 
 // Копируем функцию slugify прямо сюда
 function slugify(text: string) {
@@ -348,3 +349,5 @@ const fetchData = async () => {
     </AdminLayout>
   );
 }
+
+export const getServerSideProps = withAdminAccess();

--- a/pages/admin/categories.tsx
+++ b/pages/admin/categories.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import Head from 'next/head';
 import AdminLayout from '@/components/AdminLayout';
+import { withAdminAccess } from '@/lib/withAdminAccess';
 
 export default function AdminCategoriesPage() {
   const [categories, setCategories] = useState([]);
@@ -132,4 +133,6 @@ export default function AdminCategoriesPage() {
     </AdminLayout>
   );
 }
+
+export const getServerSideProps = withAdminAccess();
 

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,0 +1,28 @@
+import Head from 'next/head';
+import AdminLayout from '@/components/AdminLayout';
+import { withAdminAccess } from '@/lib/withAdminAccess';
+import Link from 'next/link';
+
+export default function AdminHome() {
+  return (
+    <AdminLayout>
+      <Head>
+        <title>Админка</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Админка</h1>
+      <ul className="list-disc pl-5 space-y-2">
+        <li>
+          <Link href="/admin/users">Пользователи</Link>
+        </li>
+        <li>
+          <Link href="/admin/categories">Категории</Link>
+        </li>
+        <li>
+          <Link href="/admin/agents">Агенты</Link>
+        </li>
+      </ul>
+    </AdminLayout>
+  );
+}
+
+export const getServerSideProps = withAdminAccess();

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
 import AdminLayout from '@/components/AdminLayout';
+import { withAdminAccess } from '@/lib/withAdminAccess';
 
 interface User {
   id: number;
@@ -96,3 +97,5 @@ export default function AdminUsersPage() {
     </AdminLayout>
   );
 }
+
+export const getServerSideProps = withAdminAccess();

--- a/pages/api/agents.ts
+++ b/pages/api/agents.ts
@@ -1,10 +1,15 @@
 // pages/api/agents.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Database from 'better-sqlite3';
+import { parse } from 'cookie';
 
 const db = new Database('./data/users.db');
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = req.headers.cookie ? parse(req.headers.cookie) : {};
+  if (cookies.userEmail !== 'kcc-kem@ya.ru') {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
   console.log(`API вызван с методом: ${req.method}`);
   console.log('Тело запроса:', req.body);
 

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -1,8 +1,13 @@
 //pages/api/categories.ts
 
 import Database from 'better-sqlite3';
+import { parse } from 'cookie';
 
 export default function handler(req, res) {
+  const cookies = req.headers.cookie ? parse(req.headers.cookie) : {};
+  if (cookies.userEmail !== 'kcc-kem@ya.ru') {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
   const db = new Database('./data/users.db');
 
   // Получить все категории

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -16,10 +16,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const isMatch = await bcrypt.compare(password, user.password);
   if (!isMatch) return res.status(401).json({ message: 'Неверный пароль', success: false });
 
-  res.setHeader('Set-Cookie', serialize('user', String(user.id), {
-    path: '/',
-    maxAge: 60 * 60 * 24 * 3, // 3 дня
-  }));
+  res.setHeader('Set-Cookie', [
+    serialize('user', String(user.id), {
+      path: '/',
+      maxAge: 60 * 60 * 24 * 3, // 3 дня
+    }),
+    serialize('userEmail', user.email, {
+      path: '/',
+      maxAge: 60 * 60 * 24 * 3,
+    }),
+  ]);
 
   res.json({ message: 'Успешный вход', success: true });
 }

--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -2,8 +2,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { open } from 'sqlite';
 import sqlite3 from 'sqlite3';
+import { parse } from 'cookie';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = req.headers.cookie ? parse(req.headers.cookie) : {};
+  if (cookies.userEmail !== 'kcc-kem@ya.ru') {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
   if (req.method !== 'GET') return res.status(405).end();
 
   const db = await open({ filename: './data/users.db', driver: sqlite3.Database });


### PR DESCRIPTION
## Summary
- implement `withAdminAccess` helper for SSR admin checks
- store `userEmail` cookie on login
- protect admin API routes
- gate all admin pages with server-side access verification
- add `/admin` index page

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6860dcae8cf083289ea5e8bfc8e58c0a