### PR TITLE
Implement category pages with pagination and slug-based chat

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -2,7 +2,7 @@
  
 import Link from 'next/link';
 import { useCategoryStore } from '@/store/categoryStore';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 interface SidebarProps {
   sidebarOpen: boolean;
@@ -17,8 +17,16 @@ export default function Sidebar({
   userEmail,
   subscriptionStatus,
 }: SidebarProps) {
-  const { categories } = useCategoryStore();
+  const { categories, setCategories } = useCategoryStore();
   const [userMenuOpen, setUserMenuOpen] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/categories?limit=5')
+      .then(res => res.json())
+      .then(data => {
+        if (data.categories) setCategories(data.categories);
+      });
+  }, [setCategories]);
 
 	const toggleUserMenu = () => {
 	  setUserMenuOpen(prev => !prev);
@@ -40,7 +48,7 @@ export default function Sidebar({
 			<h4><a className="color" href="/dashboard">Главная</a></h4>
             <h4>Категории</h4>
             <ul className="sidebar-menu">			
-              {categories.map(cat => (
+              {categories.slice(0, 5).map(cat => (
 				  <li key={cat.id} className="sidebar-menu-item">
 					<Link href={`/categories/${cat.name}`} className="sidebar-link">
 					  {cat.name}

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -10,9 +10,26 @@ export default function handler(req, res) {
   }
   const db = new Database('./data/users.db');
 
-  // Получить все категории
+  // Получить категории
   if (req.method === 'GET') {
-    const categories = db.prepare('SELECT * FROM agent_categories').all();
+    const { limit, offset = 0, name } = req.query as any;
+
+    if (name) {
+      const category = db
+        .prepare('SELECT * FROM agent_categories WHERE name = ?')
+        .get(name);
+      return res.status(200).json({ category });
+    }
+
+    let query = 'SELECT * FROM agent_categories';
+    const params: any[] = [];
+
+    if (limit) {
+      query += ' LIMIT ? OFFSET ?';
+      params.push(Number(limit), Number(offset));
+    }
+
+    const categories = db.prepare(query).all(...params);
     return res.status(200).json({ categories });
   }
 

--- a/pages/categories/index.tsx
+++ b/pages/categories/index.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import Sidebar from '@/components/Sidebar';
+
+export default function CategoriesPage() {
+  const [email, setEmail] = useState('');
+  const [subscriptionStatus, setSubscriptionStatus] = useState<'active' | 'trial' | 'expired'>('trial');
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [categories, setCategories] = useState<any[]>([]);
+  const [agentsByCat, setAgentsByCat] = useState<Record<number, any[]>>({});
+  const [page, setPage] = useState(0); // number of extra pages loaded
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/me')
+      .then(res => res.json())
+      .then(data => {
+        if (!data.email) {
+          window.location.href = '/auth/login';
+        } else {
+          setEmail(data.email);
+          setSubscriptionStatus(data.subscriptionStatus || 'expired');
+        }
+      });
+  }, []);
+
+  useEffect(() => {
+    loadInitial();
+  }, []);
+
+  const loadInitial = async () => {
+    const res = await fetch('/api/categories?limit=5&offset=0');
+    const data = await res.json();
+    const cats = data.categories || [];
+    setCategories(cats);
+    for (const cat of cats) {
+      await loadAgents(cat.id, 8);
+    }
+    setLoading(false);
+  };
+
+  const loadAgents = async (categoryId: number, limit = 8) => {
+    const res = await fetch(`/api/agents?categoryId=${categoryId}&limit=${limit}`);
+    const data = await res.json();
+    setAgentsByCat(prev => ({ ...prev, [categoryId]: data.agents || [] }));
+  };
+
+  const loadMore = async () => {
+    setLoadingMore(true);
+    const offset = 5 + page * 10;
+    const res = await fetch(`/api/categories?limit=10&offset=${offset}`);
+    const data = await res.json();
+    const cats = data.categories || [];
+    setCategories(prev => [...prev, ...cats]);
+    for (const cat of cats) {
+      await loadAgents(cat.id, 8);
+    }
+    setPage(prev => prev + 1);
+    if (cats.length === 0) setHasMore(false);
+    setLoadingMore(false);
+  };
+
+  return (
+    <div className="dashboard-layout">
+      <Sidebar
+        sidebarOpen={sidebarOpen}
+        toggleSidebar={() => setSidebarOpen(!sidebarOpen)}
+        userEmail={email}
+        subscriptionStatus={subscriptionStatus}
+      />
+
+      <main className={`main-content ${sidebarOpen ? 'with-sidebar' : 'full-width'} p-6`}>
+        <h1 className="text-2xl font-bold mb-6">Категории</h1>
+
+        {loading ? (
+          <div>Загрузка...</div>
+        ) : (
+          categories.map(cat => (
+            <section key={cat.id} className="mb-8">
+              <h2 className="text-xl font-semibold mb-3">
+                <Link href={`/categories/${cat.name}`}>{cat.name}</Link>
+              </h2>
+              <div className="agents-grid">
+                {(agentsByCat[cat.id] || []).map(agent => (
+                  <Link key={agent.id} href={`/agents/${agent.slug}`} className="agent-card-link">
+                    <div className="agent-card">
+                      <h3 className="agent-title">{agent.name}</h3>
+                      <p className="agent-description">{agent.short_description || agent.description}</p>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          ))
+        )}
+
+        {hasMore && (
+          <div className="text-center mt-4">
+            <button onClick={loadMore} disabled={loadingMore} className="see-all-button">
+              {loadingMore ? 'Загрузка...' : 'Показать ещё'}
+            </button>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/store/agentStore.ts
+++ b/store/agentStore.ts
@@ -16,6 +16,7 @@ interface AgentStore {
   addAgent: (agent: Omit<Agent, 'id'>) => void; // ID генерируется автоматически
   updateAgent: (id: string, updates: Partial<Omit<Agent, 'id'>>) => void; // ID нельзя изменить
   deleteAgent: (id: string) => void;
+  setAgents: (agents: Agent[]) => void;
 }
 
 export const useAgentStore = create<AgentStore>()(
@@ -38,6 +39,10 @@ export const useAgentStore = create<AgentStore>()(
       deleteAgent: (id) =>
         set((state) => ({
           agents: state.agents.filter((agent) => agent.id !== id),
+        })),
+      setAgents: (agents) =>
+        set(() => ({
+          agents,
         })),
     }),
     {

--- a/store/categoryStore.ts
+++ b/store/categoryStore.ts
@@ -11,6 +11,7 @@ interface CategoryStore {
   addCategory: (name: string) => void;
   renameCategory: (id: number, name: string) => void;
   deleteCategory: (id: number) => void;
+  setCategories: (categories: Category[]) => void;
 }
 
 export const useCategoryStore = create<CategoryStore>()(
@@ -34,6 +35,10 @@ export const useCategoryStore = create<CategoryStore>()(
       deleteCategory: (id) =>
         set((state) => ({
           categories: state.categories.filter((cat) => cat.id !== id),
+        })),
+      setCategories: (categories) =>
+        set(() => ({
+          categories,
         })),
     }),
     {


### PR DESCRIPTION
## Summary
- fetch categories from the backend inside the sidebar and limit to five items
- add Zustand setters for categories and agents
- extend API endpoints to support filtering and pagination
- create `/categories` index page to show categories and their agents
- rewrite `/categories/[name]` page to load agents from the API with pagination
- rename chat page to `/agents/[slug]` and load agent info by slug

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6860f7f8f7408328bd9b184ac6a227e6