### PR TITLE
Fix users API to fetch SQLite data

### DIFF
--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -1,12 +1,13 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import sqlite3 from 'sqlite3';
 import { open } from 'sqlite';
+import bcrypt from 'bcrypt';
 
 // Открываем соединение с базой данных
 async function openDb() {
   return open({
     filename: './data/users.db',
-    driver: sqlite3.Database
+    driver: sqlite3.Database,
   });
 }
 
@@ -16,47 +17,54 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     db = await openDb();
 
     if (req.method === 'GET') {
-      // Добавляем проверку существования таблицы
-      const tableExists = await db.get("SELECT name FROM sqlite_master WHERE type='table' AND name='users'");
-      if (!tableExists) {
-        console.error('Table users does not exist');
-        return res.status(500).json({ error: 'Database table not found' });
+      // Проверяем наличие таблицы и нужных колонок
+      const columns = await db.all("PRAGMA table_info(users)");
+      const columnNames = columns.map(c => c.name);
+      if (!columnNames.includes('id') || !columnNames.includes('email') || !columnNames.includes('created_at')) {
+        console.error('Required columns are missing in users table');
+        return res.status(500).json({ error: 'Invalid users table schema' });
       }
 
-      const users = await db.all(`
-        SELECT id, email, name, created_at, 
-               is_active, subscription_status 
-        FROM users
-      `);
-      console.log('Fetched users:', users); // Для отладки
+      const hasName = columnNames.includes('name');
+      const query = hasName
+        ? 'SELECT id, email, name, created_at FROM users'
+        : 'SELECT id, email, created_at FROM users';
+      const rows = await db.all(query);
+      const users = hasName ? rows : rows.map(r => ({ ...r, name: null }));
+
       res.status(200).json(users);
     } 
     else if (req.method === 'POST') {
       const { email, password, name } = req.body;
-      
+
       if (!email || !password) {
         return res.status(400).json({ error: 'Email and password are required' });
       }
 
       try {
-        const result = await db.run(`
-          INSERT INTO users (
-            email, 
-            password_hash, 
-            name, 
-            created_at,
-            is_active,
-            subscription_status
-          ) VALUES (?, ?, ?, datetime('now'), true, 'trial')
-        `, [email, password, name || null]);
-        
-        const newUser = await db.get(`
-          SELECT id, email, name, created_at, 
-                 is_active, subscription_status 
-          FROM users 
-          WHERE id = ?
-        `, result.lastID);
-        
+        const columns = await db.all("PRAGMA table_info(users)");
+        const columnNames = columns.map(c => c.name);
+        const hasName = columnNames.includes('name');
+
+        const hashedPassword = await bcrypt.hash(password, 10);
+
+        const insertQuery = hasName
+          ? 'INSERT INTO users (email, password, name, created_at) VALUES (?, ?, ?, ?)'
+          : 'INSERT INTO users (email, password, created_at) VALUES (?, ?, ?)';
+        const params = hasName
+          ? [email, hashedPassword, name || null, new Date().toISOString()]
+          : [email, hashedPassword, new Date().toISOString()];
+
+        const result = await db.run(insertQuery, params);
+
+        const selectQuery = hasName
+          ? 'SELECT id, email, name, created_at FROM users WHERE id = ?'
+          : 'SELECT id, email, created_at FROM users WHERE id = ?';
+        const newUser: any = await db.get(selectQuery, result.lastID);
+        if (!hasName) {
+          newUser.name = null;
+        }
+
         res.status(201).json(newUser);
       } catch (error: any) {
         console.error('Insert error:', error);


### PR DESCRIPTION
## Summary
- fix `/api/users` endpoint to work with SQLite database
- handle optional `name` column and use bcrypt for passwords

## Testing
- `npm test` *(fails: Missing script)*
- `npx next build` *(fails: requires Next.js install)*

------
https://chatgpt.com/codex/tasks/task_e_686767ef14a083288d63e114f66c65f1