### PR TITLE
Fix admin sidebar duplication and layout

### DIFF
--- a/components/AdminLayout.tsx
+++ b/components/AdminLayout.tsx
@@ -30,7 +30,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   return (
     <div className="min-h-screen bg-gray-100">
       <AdminSidebar sidebarOpen={sidebarOpen} toggleSidebar={toggleSidebar} />
-      <main className={`transition-all duration-300 ${sidebarOpen ? 'ml-64' : 'ml-16'} p-8`}>
+      <main className={`transition-all duration-300 ${sidebarOpen ? 'ml-52' : 'ml-16'} p-8`}>
         {children}
       </main>
     </div>

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -16,9 +16,9 @@ export default function AdminSidebar({
   const [userMenuOpen, setUserMenuOpen] = useState(false);
 
   const menuItems = [
-    { href: '/admin/agents', label: '👥 ИИ-Агенты' },
-    { href: '/admin/categories', label: '📁 Категории' },
-    { href: '/admin/users', label: '👤 Пользователи' }
+    { href: '/admin/agents', label: 'ИИ-Агенты 📁' },
+    { href: '/admin/categories', label: 'Категории 👤' },
+    { href: '/admin/users', label: 'Пользователи' }
   ];
 
   const toggleUserMenu = () => {
@@ -27,7 +27,7 @@ export default function AdminSidebar({
 
   return (
     <aside className={`fixed top-0 left-0 h-full bg-gray-900 text-white transition-all duration-300 z-50 ${
-      sidebarOpen ? 'w-64' : 'w-16'
+      sidebarOpen ? 'w-52' : 'w-16'
     }`}>
       <div className="flex flex-col h-full">
         <div className="flex items-center justify-between p-4 border-b border-gray-800">

--- a/pages/admin/agents.tsx
+++ b/pages/admin/agents.tsx
@@ -1,7 +1,6 @@
 // pages/admin/agents.tsx
 import { useState } from 'react';
 import Head from 'next/head';
-import AdminLayout from '@/components/AdminLayout';
 import { useAgentStore } from '@/store/agentStore';
 import { useCategoryStore } from '@/store/categoryStore';
 
@@ -30,7 +29,7 @@ export default function AdminAgentsPage() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <Head>
         <title>Админка — Агенты</title>
       </Head>
@@ -146,6 +145,6 @@ export default function AdminAgentsPage() {
           ))}
         </tbody>
       </table>
-    </AdminLayout>
+    </>
   );
 }

--- a/pages/admin/categories.tsx
+++ b/pages/admin/categories.tsx
@@ -1,7 +1,6 @@
 // pages/admin/categories.tsx
 import { useState } from 'react';
 import Head from 'next/head';
-import AdminLayout from '@/components/AdminLayout';
 import { useCategoryStore } from '@/store/categoryStore';
 
 export default function AdminCategoriesPage() {
@@ -15,7 +14,7 @@ export default function AdminCategoriesPage() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <Head>
         <title>Админка — Категории</title>
       </Head>
@@ -70,6 +69,6 @@ export default function AdminCategoriesPage() {
           ))}
         </tbody>
       </table>
-    </AdminLayout>
+    </>
   );
 }

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -1,7 +1,6 @@
 // pages/admin/users.tsx
 import { useState, useEffect } from 'react';
 import Head from 'next/head';
-import AdminLayout from '@/components/AdminLayout';
 
 interface User {
   id: number;
@@ -78,7 +77,7 @@ export default function AdminUsersPage() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <Head>
         <title>Админка — Пользователи</title>
       </Head>
@@ -153,6 +152,6 @@ export default function AdminUsersPage() {
           )}
         </div>
       </div>
-    </AdminLayout>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- remove redundant `<AdminLayout>` wrappers on admin pages
- adjust sidebar width to 200px and update content margin
- clean up menu labels and icons

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868e2b9592083288558c7afb3a38419