### PR TITLE
Fix cookie session

### DIFF
--- a/components/AdminLayout.tsx
+++ b/components/AdminLayout.tsx
@@ -14,7 +14,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
   const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
-    fetch('/api/me')
+    fetch('/api/me', { credentials: 'include' })
       .then((res) => res.json())
       .then((data) => {
         if (!data.isAdmin) {

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -6,7 +6,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   const [subscriptionStatus, setSubscriptionStatus] = useState<'trial' | 'active' | 'expired'>('expired');
 
   useEffect(() => {
-    fetch('/api/me')
+    fetch('/api/me', { credentials: 'include' })
       .then(res => res.json())
       .then(data => setSubscriptionStatus(data.subscriptionStatus));
   }, []);

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -28,7 +28,9 @@ export default function Sidebar({
 
   const handleLogout = async () => {
     try {
-      const response = await fetch('/api/logout');
+      const response = await fetch('/api/logout', {
+        credentials: 'include'
+      });
       if (response.ok) {
         router.push('/auth/login');
       }

--- a/pages/agents/[id].tsx
+++ b/pages/agents/[id].tsx
@@ -117,7 +117,7 @@ export default function AgentChat() {
   }, [messages]);
 
   useEffect(() => {
-    fetch('/api/me')
+    fetch('/api/me', { credentials: 'include' })
       .then(res => res.json())
       .then(data => {
         if (!data.email) {

--- a/pages/agents/index.tsx
+++ b/pages/agents/index.tsx
@@ -15,7 +15,7 @@ export default function AgentsPage() {
   const { agents } = useAgentStore();
 
   useEffect(() => {
-    fetch('/api/me')
+    fetch('/api/me', { credentials: 'include' })
       .then(res => res.json())
       .then(data => {
         if (!data.email) {

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -3,6 +3,7 @@ import bcrypt from 'bcrypt';
 import { open } from 'sqlite';
 import sqlite3 from 'sqlite3';
 import { serialize } from 'cookie';
+import crypto from 'crypto';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
@@ -25,9 +26,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     maxAge: 60 * 60 * 24 * 3 // 3 дня
   };
 
+  const token = crypto.randomBytes(16).toString('hex');
+
   res.setHeader('Set-Cookie', [
     serialize('email', email, cookieOptions),
-    serialize('user_id', String(user.id), cookieOptions)
+    serialize('user_id', String(user.id), cookieOptions),
+    serialize('token', token, cookieOptions)
   ]);
 
   await db.close();

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -17,6 +17,7 @@ export default function Login() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),
+        credentials: 'include'
       });
       
       const result = await res.json();

--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -36,7 +36,7 @@ const toggleSidebar = () => { setSidebarOpen(prev => !prev);
   }, [router.isReady, router.query.name, agents, categories]);
 
   useEffect(() => {
-    fetch('/api/me')
+    fetch('/api/me', { credentials: 'include' })
       .then(res => res.json())
       .then(data => {
         if (!data.email) {

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -38,7 +38,7 @@ export default function Dashboard() {
   const { categories } = useCategoryStore();
 
   useEffect(() => {
-    fetch('/api/me')
+    fetch('/api/me', { credentials: 'include' })
       .then(res => res.json())
       .then(data => {
         if (!data.email) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ export default function Home() {
   const [checking, setChecking] = useState(true);
 
   useEffect(() => {
-    fetch('/api/me')
+    fetch('/api/me', { credentials: 'include' })
       .then(res => res.json())
       .then(data => {
         if (data?.email) {

--- a/pages/subscribe.tsx
+++ b/pages/subscribe.tsx
@@ -6,7 +6,7 @@ export default function SubscribePage() {
   const [subscriptionStatus, setSubscriptionStatus] = useState<'trial' | 'active' | 'expired'>('trial');
 
   useEffect(() => {
-    fetch('/api/me')
+    fetch('/api/me', { credentials: 'include' })
       .then(res => res.json())
       .then(data => {
         setSubscriptionStatus(data.subscriptionStatus || 'expired');


### PR DESCRIPTION
## Summary
- generate a `token` cookie on login
- include credentials when calling API endpoints so cookies persist

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869179fd6c88328886df25fdde729a1