### PR TITLE
Fix cookie session handling for /api/me

### DIFF
--- a/pages/api/me.ts
+++ b/pages/api/me.ts
@@ -1,18 +1,22 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const cookies = req.headers.cookie || '';
-  const emailCookie = cookies.split(';').find(c => c.trim().startsWith('email='));
-  const email = emailCookie ? decodeURIComponent(emailCookie.split('=')[1]) : null;
-  const hasPaid = cookies.includes('subscriptionPaid=true');
+  const { email, subscriptionPaid } = req.cookies as {
+    email?: string;
+    subscriptionPaid?: string;
+  };
 
-  if (!email) {
+  const decodedEmail = email ? decodeURIComponent(email) : null;
+
+  if (!decodedEmail) {
     return res.status(401).json({ error: 'Not authenticated' });
   }
 
   const now = new Date();
   const registered = new Date(); // Используем текущую дату как дату регистрации
   const diffInDays = Math.floor((now.getTime() - registered.getTime()) / (1000 * 60 * 60 * 24));
+
+  const hasPaid = subscriptionPaid === 'true';
 
   let status: 'trial' | 'active' | 'expired' = 'expired';
 
@@ -23,10 +27,10 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   res.status(200).json({
-    email,
+    email: decodedEmail,
     registeredAt: registered.toISOString(),
     subscriptionStatus: status,
     trialEndsIn: 3 - diffInDays,
-    isAdmin: email === 'kcc-kem@ya.ru'
+    isAdmin: decodedEmail === 'kcc-kem@ya.ru'
   });
 }


### PR DESCRIPTION
## Summary
- handle cookies with `req.cookies` in `/api/me`
- keep `credentials: 'include'` on login page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869201fc5dc8328b5578ef2203fffd3