### PR TITLE
Fix category layout with agents grid and logging

### DIFF
--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -22,6 +22,8 @@ export default function CategoryPage() {
       .catch(() => setLoading(false));
   }, [slug]);
 
+  console.log('Loaded agents for category:', agents);
+
   if (loading) {
     return (
       <Layout>
@@ -42,9 +44,11 @@ export default function CategoryPage() {
     <Layout>
       <h1 className="text-2xl font-bold mb-4">{category.name}</h1>
       <div className="agents-grid">
-        {agents.map(agent => (
-          <AgentCard key={agent.id} {...agent} />
-        ))}
+        {agents.length === 0 ? (
+          <p>Агенты не найдены</p>
+        ) : (
+          agents.map(agent => <AgentCard key={agent.id} {...agent} />)
+        )}
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- wrap category page content in site layout
- log fetched agents and render fallback message if none

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e75f696008328b056bca3c0b384dc