### PR TITLE
Update category page with dashboard layout

### DIFF
--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -1,23 +1,70 @@
+// pages/categories/[name].tsx
+import { useRouter } from 'next/router';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import Sidebar from '@/components/Sidebar';
 import HamburgerIcon from '@/components/HamburgerIcon';
 import CloseIcon from '@/components/CloseIcon';
-import Link from 'next/link';
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/router';
 
-export default function CategoryPage() {
+export default function AgentPage() {
+  const router = useRouter();
+  const categoryTitle = Array.isArray(router.query.name)
+    ? router.query.name[0]
+    : router.query.name || '';
+
+  const [email, setEmail] = useState('');
+  const [subscriptionStatus, setSubscriptionStatus] = useState<'active' | 'trial' | 'expired'>('trial');
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
-  const [agents, setAgents] = useState<any[]>([]);
-  const [category, setCategory] = useState<any>(null);
-  const [email, setEmail] = useState('');
-  const [subscriptionStatus, setSubscriptionStatus] = useState<'trial' | 'active' | 'expired'>('trial');
-  const router = useRouter();
-  const slug = router.query.name as string;
 
   useEffect(() => {
     setSidebarOpen(window.innerWidth > 768);
   }, []);
+
+
+  const [categories, setCategories] = useState<any[]>([]);
+  const [agents, setAgents] = useState<any[]>([]);
+
+  const [categoryAgents, setCategoryAgents] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  
+const toggleSidebar = () => { setSidebarOpen(prev => !prev); };
+const toggleUserMenu = () => setUserMenuOpen(!userMenuOpen);
+
+const handleLogout = async () => {
+  try {
+    const res = await fetch('/api/logout', { credentials: 'include' });
+    if (res.ok) {
+      window.location.href = '/auth/login';
+    }
+  } catch (e) {
+    console.error('Ошибка при выходе:', e);
+  }
+};
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/api/categories').then(r => r.json()),
+      fetch('/api/agents').then(r => r.json()),
+    ])
+      .then(([cats, ags]) => {
+        setCategories(cats);
+        setAgents(ags);
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (router.isReady && router.query.name && agents.length > 0 && categories.length > 0) {
+      const categoryName = Array.isArray(router.query.name) ? router.query.name[0] : router.query.name;
+      const currentCategory = categories.find(cat => cat.name === categoryName);
+      const categoryId = currentCategory?.id;
+      const filtered = agents.filter(agent => agent.category_id === categoryId);
+      setCategoryAgents(filtered);
+      setLoading(false);
+    }
+  }, [router.isReady, router.query.name, agents, categories]);
 
   useEffect(() => {
     fetch('/api/me', { credentials: 'include' })
@@ -32,55 +79,35 @@ export default function CategoryPage() {
       });
   }, []);
 
-  const toggleSidebar = () => setSidebarOpen(o => !o);
-  const toggleUserMenu = () => setUserMenuOpen(o => !o);
-
-  const handleLogout = async () => {
-    try {
-      const res = await fetch('/api/logout', { credentials: 'include' });
-      if (res.ok) {
-        window.location.href = '/auth/login';
-      }
-    } catch (e) {
-      console.error('Ошибка при выходе:', e);
-    }
-  };
-
-  useEffect(() => {
-    if (!slug) return;
-    fetch(`/api/categories/${encodeURIComponent(slug)}`)
-      .then(r => r.json())
-      .then(data => {
-        console.log('Received category data:', data);
-        setCategory(data.category);
-        setAgents(data.agents || []);
-      })
-      .catch(err => {
-        console.error('Error loading category:', err);
-      });
-  }, [slug]);
-
-  if (!category) {
-    return <p>Категория не найдена</p>;
+  if (!router.isReady || loading) {
+    return <div>Загрузка...</div>;
   }
+
+  console.log('Agents for render:', categoryAgents);
 
   return (
     <div className="dashboard-layout">
-      <Sidebar
-        sidebarOpen={sidebarOpen}
-        toggleSidebar={toggleSidebar}
-        userEmail={email}
-        subscriptionStatus={subscriptionStatus}
-      />
+      <Head>
+        <title>Агенты категории</title>
+      </Head>
 
-      <main className={`main-content ${sidebarOpen ? 'with-sidebar' : 'full-width'}`}>
+          <Sidebar
+  sidebarOpen={sidebarOpen}
+  toggleSidebar={toggleSidebar}
+  userEmail={email}
+  subscriptionStatus={subscriptionStatus}  
+/>
+
+      <main className={`main-content ${sidebarOpen ? 'with-sidebar' : 'full-width'} p-6`}>
         <header className="lk-header">
           <button className="mobile-hamburger" onClick={toggleSidebar}>
             {sidebarOpen ? <CloseIcon /> : <HamburgerIcon />}
           </button>
-          <h1 className="section-title">{category?.name || 'Загрузка…'}</h1>
+          <h1 className="header__title">{categoryTitle}</h1>
           <div className="header__user" onClick={toggleUserMenu}>
-            <span className="user-avatar">{email.charAt(0).toUpperCase()}</span>
+            <span className="user-avatar">
+              {email.charAt(0).toUpperCase()}
+            </span>
             {userMenuOpen && (
               <ul className="dropdown-menu">
                 <li>
@@ -93,23 +120,27 @@ export default function CategoryPage() {
             )}
           </div>
         </header>
-
-        <section className="content-section">
-          {agents.length > 0 ? (
-            <div className="agents-grid">
-              {agents.map(agent => (
-                <Link key={agent.id} href={`/agents/${agent.id}`} className="agent-card-link">
-                  <div className="agent-card">
-                    <h4 className="agent-title">{agent.name}</h4>
-                    <p className="agent-description">{agent.short_description}</p>
-                  </div>
-                </Link>
-              ))}
+        <h1 className="section-title text-2xl font-bold mb-6">{categoryTitle}</h1>
+		
+		 {(subscriptionStatus === 'expired' || subscriptionStatus === 'trial') && (
+            <div className="access-warning">
+              <h3>🔓 Доступ ограничен</h3>
+              <p>Чтобы пользоваться всеми ИИ-помощниками без ограничений, оформите подписку.</p>
             </div>
-          ) : (
-            <p>Нет агентов в этой категории.</p>
           )}
-        </section>
+
+        {categoryAgents.length === 0 && <p>Нет агентов в этой категории.</p>}
+
+        <div className="agents-grid">
+          {categoryAgents.map(agent => (
+            <Link key={agent.id} href={`/agents/${agent.id}`} className="agent-card-link">
+              <div className="agent-card">
+                <h4 className="agent-title">{agent.name}</h4>
+                <p className="agent-description">{agent.short_description}</p>
+              </div>
+            </Link>
+          ))}
+        </div>
       </main>
     </div>
   );

--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -46,26 +46,45 @@ const handleLogout = async () => {
 
   useEffect(() => {
     Promise.all([
-      fetch('/api/categories').then(r => r.json()),
-      fetch('/api/agents').then(r => r.json()),
+      fetch('/api/categories', { credentials: 'include' })
+        .then(r => {
+          console.log('Fetch /api/categories status:', r.status);
+          return r.json();
+        }),
+      fetch('/api/agents', { credentials: 'include' })
+        .then(r => {
+          console.log('Fetch /api/agents status:', r.status);
+          return r.json();
+        }),
     ])
       .then(([cats, ags]) => {
+        console.log('Loaded categories:', cats);
+        console.log('Loaded agents:', ags);
         setCategories(cats);
         setAgents(ags);
       })
-      .catch(() => {});
+      .catch(err => console.error('Error loading cats/agents:', err));
   }, []);
 
   useEffect(() => {
-    if (router.isReady && router.query.name && agents.length > 0 && categories.length > 0) {
-      const categoryName = Array.isArray(router.query.name) ? router.query.name[0] : router.query.name;
-      const currentCategory = categories.find(cat => cat.name === categoryName);
-      const categoryId = currentCategory?.id;
-      const filtered = agents.filter(agent => agent.category_id === categoryId);
-      setCategoryAgents(filtered);
-      setLoading(false);
-    }
-  }, [router.isReady, router.query.name, agents, categories]);
+    if (!router.isReady || !agents.length || !categories.length) return;
+
+    const categoryName = Array.isArray(router.query.name)
+      ? router.query.name[0]
+      : router.query.name;
+    console.log('Current slug:', categoryName);
+    console.log('All categories:', categories);
+    console.log('All agents:', agents);
+
+    const currentCategory = categories.find(cat => cat.name === categoryName);
+    console.log('Matched category object:', currentCategory);
+
+    const filtered = agents.filter(agent => agent.category_id === currentCategory?.id);
+    console.log('Filtered agents for render:', filtered);
+
+    setCategoryAgents(filtered);
+    setLoading(false);
+  }, [router.isReady, agents, categories]);
 
   useEffect(() => {
     fetch('/api/me', { credentials: 'include' })

--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -47,14 +47,14 @@ const handleLogout = async () => {
   useEffect(() => {
     Promise.all([
       fetch('/api/categories', { credentials: 'include' })
-        .then(r => {
-          console.log('Fetch /api/categories status:', r.status);
-          return r.json();
+        .then(res => {
+          console.log('[categories] status:', res.status);
+          return res.json();
         }),
       fetch('/api/agents', { credentials: 'include' })
-        .then(r => {
-          console.log('Fetch /api/agents status:', r.status);
-          return r.json();
+        .then(res => {
+          console.log('[agents] status:', res.status);
+          return res.json();
         }),
     ])
       .then(([cats, ags]) => {
@@ -63,7 +63,7 @@ const handleLogout = async () => {
         setCategories(cats);
         setAgents(ags);
       })
-      .catch(err => console.error('Error loading cats/agents:', err));
+      .catch(err => console.error('Fetch error:', err));
   }, []);
 
   useEffect(() => {

--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -76,10 +76,14 @@ const handleLogout = async () => {
     console.log('All categories:', categories);
     console.log('All agents:', agents);
 
-    const currentCategory = categories.find(cat => cat.name === categoryName);
+  const currentCategory = categories.find(
+    cat => cat.slug.toLowerCase() === String(categoryName).toLowerCase()
+  );
     console.log('Matched category object:', currentCategory);
 
-    const filtered = agents.filter(agent => agent.category_id === currentCategory?.id);
+  const filtered = currentCategory
+    ? agents.filter(agent => agent.category_id === currentCategory.id)
+    : [];
     console.log('Filtered agents for render:', filtered);
 
     setCategoryAgents(filtered);

--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -1,51 +1,116 @@
+import Sidebar from '@/components/Sidebar';
+import HamburgerIcon from '@/components/HamburgerIcon';
+import CloseIcon from '@/components/CloseIcon';
+import Link from 'next/link';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
-import Layout from '@/components/Layout';
-import AgentCard from '@/components/AgentCard';
 
 export default function CategoryPage() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const [agents, setAgents] = useState<any[]>([]);
+  const [category, setCategory] = useState<any>(null);
+  const [email, setEmail] = useState('');
+  const [subscriptionStatus, setSubscriptionStatus] = useState<'trial' | 'active' | 'expired'>('trial');
   const router = useRouter();
   const slug = router.query.name as string;
-  const [category, setCategory] = useState<any>(null);
-  const [agents, setAgents] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setSidebarOpen(window.innerWidth > 768);
+  }, []);
+
+  useEffect(() => {
+    fetch('/api/me', { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => {
+        if (!data.email) {
+          window.location.href = '/auth/login';
+        } else {
+          setEmail(data.email);
+          setSubscriptionStatus(data.subscriptionStatus || 'expired');
+        }
+      });
+  }, []);
+
+  const toggleSidebar = () => setSidebarOpen(o => !o);
+  const toggleUserMenu = () => setUserMenuOpen(o => !o);
+
+  const handleLogout = async () => {
+    try {
+      const res = await fetch('/api/logout', { credentials: 'include' });
+      if (res.ok) {
+        window.location.href = '/auth/login';
+      }
+    } catch (e) {
+      console.error('Ошибка при выходе:', e);
+    }
+  };
 
   useEffect(() => {
     if (!slug) return;
-    fetch(`/api/categories/${slug}`)
-      .then(res => res.json())
+    fetch(`/api/categories/${encodeURIComponent(slug)}`)
+      .then(r => r.json())
       .then(data => {
+        console.log('Received category data:', data);
         setCategory(data.category);
-        setAgents(Array.isArray(data.agents) ? data.agents : []);
-        setLoading(false);
+        setAgents(data.agents || []);
       })
-      .catch(() => setLoading(false));
+      .catch(err => {
+        console.error('Error loading category:', err);
+      });
   }, [slug]);
 
-  if (loading) {
-    return (
-      <Layout>
-        <p>Загрузка…</p>
-      </Layout>
-    );
-  }
-
   if (!category) {
-    return (
-      <Layout>
-        <p>Категория не найдена</p>
-      </Layout>
-    );
+    return <p>Категория не найдена</p>;
   }
 
   return (
-    <Layout>
-      <h1 className="text-2xl font-bold mb-4">{category.name}</h1>
-      <div className="agents-grid">
-        {agents.map(agent => (
-          <AgentCard key={agent.id} {...agent} />
-        ))}
-      </div>
-    </Layout>
+    <div className="dashboard-layout">
+      <Sidebar
+        sidebarOpen={sidebarOpen}
+        toggleSidebar={toggleSidebar}
+        userEmail={email}
+        subscriptionStatus={subscriptionStatus}
+      />
+
+      <main className={`main-content ${sidebarOpen ? 'with-sidebar' : 'full-width'}`}>
+        <header className="lk-header">
+          <button className="mobile-hamburger" onClick={toggleSidebar}>
+            {sidebarOpen ? <CloseIcon /> : <HamburgerIcon />}
+          </button>
+          <h1 className="section-title">{category?.name || 'Загрузка…'}</h1>
+          <div className="header__user" onClick={toggleUserMenu}>
+            <span className="user-avatar">{email.charAt(0).toUpperCase()}</span>
+            {userMenuOpen && (
+              <ul className="dropdown-menu">
+                <li>
+                  <Link href="/profile">Профиль</Link>
+                </li>
+                <li>
+                  <button onClick={handleLogout}>Выйти</button>
+                </li>
+              </ul>
+            )}
+          </div>
+        </header>
+
+        <section className="content-section">
+          {agents.length > 0 ? (
+            <div className="agents-grid">
+              {agents.map(agent => (
+                <Link key={agent.id} href={`/agents/${agent.id}`} className="agent-card-link">
+                  <div className="agent-card">
+                    <h4 className="agent-title">{agent.name}</h4>
+                    <p className="agent-description">{agent.short_description}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <p>Нет агентов в этой категории.</p>
+          )}
+        </section>
+      </main>
+    </div>
   );
 }

--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -1,4 +1,5 @@
 // pages/categories/[name].tsx
+// Restored display logic from k2jylv-codex branch
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Link from 'next/link';

--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -62,32 +62,38 @@ const handleLogout = async () => {
       .catch(err => console.error('Fetch agents error:', err));
   }, []);
 
-  useEffect(() => {
-    if (!router.isReady || !agents.length || !categories.length) return;
+useEffect(() => {
+  if (!router.isReady) return;
 
-    const categoryName = Array.isArray(router.query.name)
-      ? router.query.name[0]
-      : router.query.name;
-    console.log('Current slug:', categoryName);
-    console.log('All categories:', categories);
-    console.log('All agents:', agents);
+  setLoading(true);
 
-  const nameLower = String(categoryName).toLowerCase();
+  const rawName = Array.isArray(router.query.name)
+    ? router.query.name[0]
+    : router.query.name;
+  const slugOrName = String(rawName || '').toLowerCase();
+
+  console.log('→ router.query.name:', router.query.name);
+  console.log('→ categories:', categories);
+  console.log('→ agents:', agents.length);
+
   const currentCategory = categories.find(
     cat =>
-      (cat.slug && cat.slug.toLowerCase() === nameLower) ||
-      (cat.name && cat.name.toLowerCase() === nameLower)
+      (cat.slug && cat.slug.toLowerCase() === slugOrName) ||
+      (cat.name && cat.name.toLowerCase() === slugOrName)
   );
-    console.log('Matched category object:', currentCategory);
 
-  const filtered = currentCategory
-    ? agents.filter(agent => agent.category_id === currentCategory.id)
-    : [];
-    console.log('Filtered agents for render:', filtered);
-
-    setCategoryAgents(filtered);
+  if (!currentCategory) {
+    setCategoryAgents([]);
+    console.log('→ filtered agents:', []);
     setLoading(false);
-  }, [router.isReady, agents, categories]);
+    return;
+  }
+
+  const filtered = agents.filter(a => a.category_id === currentCategory.id);
+  console.log('→ filtered agents:', filtered);
+  setCategoryAgents(filtered);
+  setLoading(false);
+}, [router.isReady, router.query.name, categories, agents]);
 
   useEffect(() => {
     fetch('/api/me', { credentials: 'include' })

--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -45,25 +45,21 @@ const handleLogout = async () => {
 };
 
   useEffect(() => {
-    Promise.all([
-      fetch('/api/categories', { credentials: 'include' })
-        .then(res => {
-          console.log('[categories] status:', res.status);
-          return res.json();
-        }),
-      fetch('/api/agents', { credentials: 'include' })
-        .then(res => {
-          console.log('[agents] status:', res.status);
-          return res.json();
-        }),
-    ])
-      .then(([cats, ags]) => {
-        console.log('Loaded categories:', cats);
-        console.log('Loaded agents:', ags);
-        setCategories(cats);
-        setAgents(ags);
+    fetch('/api/categories', { credentials: 'include' })
+      .then(r => r.json())
+      .then(data => {
+        console.log('API /categories →', data);
+        setCategories(data);
       })
-      .catch(err => console.error('Fetch error:', err));
+      .catch(err => console.error('Fetch categories error:', err));
+
+    fetch('/api/agents', { credentials: 'include' })
+      .then(r => r.json())
+      .then(data => {
+        console.log('API /agents →', data);
+        setAgents(data);
+      })
+      .catch(err => console.error('Fetch agents error:', err));
   }, []);
 
   useEffect(() => {
@@ -76,8 +72,11 @@ const handleLogout = async () => {
     console.log('All categories:', categories);
     console.log('All agents:', agents);
 
+  const nameLower = String(categoryName).toLowerCase();
   const currentCategory = categories.find(
-    cat => cat.slug.toLowerCase() === String(categoryName).toLowerCase()
+    cat =>
+      (cat.slug && cat.slug.toLowerCase() === nameLower) ||
+      (cat.name && cat.name.toLowerCase() === nameLower)
   );
     console.log('Matched category object:', currentCategory);
 


### PR DESCRIPTION
## Summary
- integrate dashboard sidebar/header on category page
- load current user details and category data
- display agents grid for the category

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3d321a6883289b08d4d731a35553