### PR TITLE
Move chat page header elements

### DIFF
--- a/components/HeartIcon.tsx
+++ b/components/HeartIcon.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function HeartIcon({ filled = false }: { filled?: boolean }) {
+  return filled ? (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 21s-7-4.35-10-9a6 6 0 0 1 10-7 6 6 0 0 1 10 7c-3 4.65-10 9-10 9z" />
+    </svg>
+  ) : (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20.8 4.6a5.5 5.5 0 0 0-7.8 0L12 5.6l-1-1a5.5 5.5 0 0 0-7.8 7.8l1 1L12 21l7.8-7.6 1-1a5.5 5.5 0 0 0 0-7.8z" />
+    </svg>
+  );
+}

--- a/pages/agents/[id].tsx
+++ b/pages/agents/[id].tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import Sidebar from '@/components/Sidebar';
 import HamburgerIcon from '@/components/HamburgerIcon';
 import CloseIcon from '@/components/CloseIcon';
+import HeartIcon from '@/components/HeartIcon';
 
 
 // Функция для форматирования текста с абзацами
@@ -105,6 +106,7 @@ export default function AgentChat() {
   const [subscriptionStatus, setSubscriptionStatus] = useState<'active' | 'trial' | 'expired'>('trial');
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const [isFavorite, setIsFavorite] = useState(false);
 
   useEffect(() => {
     setSidebarOpen(window.innerWidth > 768);
@@ -227,6 +229,17 @@ export default function AgentChat() {
     textarea.style.height = Math.min(textarea.scrollHeight, 120) + 'px';
   };
 
+  const handleClearChat = () => {
+    setMessages([]);
+    if (typeof id === 'string') {
+      localStorage.removeItem(`chat_${id}`);
+    }
+  };
+
+  const toggleFavorite = () => {
+    setIsFavorite(prev => !prev);
+  };
+
   return (
     <div className="chat-layout">
       {/* Sidebar */}
@@ -243,6 +256,17 @@ export default function AgentChat() {
           <button className="mobile-hamburger" onClick={toggleSidebar}>
             {sidebarOpen ? <CloseIcon /> : <HamburgerIcon />}
           </button>
+          <div className="header__title">
+            <h1>Чат с {assistantName}</h1>
+          </div>
+          <div className="header__actions">
+            <button className="btn-clear-chat" onClick={handleClearChat}>
+              Очистить чат
+            </button>
+            <button className="btn-favorite" onClick={toggleFavorite}>
+              <HeartIcon filled={isFavorite} />
+            </button>
+          </div>
           <div className="header__user" onClick={toggleUserMenu}>
             <span className="user-avatar">
               {email.charAt(0).toUpperCase()}
@@ -259,18 +283,6 @@ export default function AgentChat() {
             )}
           </div>
         </header>
-        <div className="chat-header">
-          <h1 className="chat-title">Чат с {assistantName}</h1>
-          <button
-            className="clear-chat-button"
-            onClick={() => {
-              setMessages([]);
-              localStorage.removeItem(`chat_${id}`);
-            }}
-          >
-            Очистить чат
-          </button>
-        </div>
 
         <div className="chat-container">
           <div className="chat-messages">

--- a/styles/global.css
+++ b/styles/global.css
@@ -1840,6 +1840,29 @@ footer.site-footer {
   font-weight: bold;
   display: block;
 }
+.header__title h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+.header__actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.btn-clear-chat {
+  padding: 0.5rem 1rem;
+  background: var(--red);
+  color: white;
+  border: none;
+  border-radius: 0.375rem;
+}
+.btn-favorite {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
 
 @media (max-width: 767px) {
   .header__title {


### PR DESCRIPTION
## Summary
- move chat page title and clear button into lk-header
- add favorite heart button
- create reusable `HeartIcon` component
- style new header actions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f89b6573c8328b87c128993c7e5c3