### PR TITLE
Add favorites feature

### DIFF
--- a/__tests__/favoritesApi.test.ts
+++ b/__tests__/favoritesApi.test.ts
@@ -1,0 +1,61 @@
+import favToggle from '../pages/api/agents/[id]/favorite'
+import listFavs from '../pages/api/users/me/favorites'
+import httpMocks from 'node-mocks-http'
+import { openDb } from '../lib/db'
+import { getSession } from '../lib/auth'
+
+jest.mock('../lib/db')
+jest.mock('../lib/auth')
+
+const mockDb = {
+  run: jest.fn(),
+  all: jest.fn(),
+  close: jest.fn()
+}
+
+beforeEach(() => {
+  (openDb as jest.Mock).mockResolvedValue(mockDb)
+  ;(getSession as jest.Mock).mockResolvedValue({ userId: 1 })
+  mockDb.run.mockReset()
+  mockDb.all.mockReset()
+  mockDb.close.mockReset()
+})
+
+test('POST adds favorite', async () => {
+  const req = httpMocks.createRequest({ method: 'POST', query: { id: 'a1' } })
+  const res = httpMocks.createResponse()
+
+  await favToggle(req, res)
+
+  expect(mockDb.run).toHaveBeenCalledWith(
+    `INSERT OR IGNORE INTO user_favorite_agents(user_id, agent_id) VALUES(?, ?);`,
+    [1, 'a1']
+  )
+  expect(res._getStatusCode()).toBe(200)
+})
+
+test('DELETE removes favorite', async () => {
+  const req = httpMocks.createRequest({ method: 'DELETE', query: { id: 'a1' } })
+  const res = httpMocks.createResponse()
+
+  await favToggle(req, res)
+
+  expect(mockDb.run).toHaveBeenCalledWith(
+    `DELETE FROM user_favorite_agents WHERE user_id = ? AND agent_id = ?;`,
+    [1, 'a1']
+  )
+  expect(res._getStatusCode()).toBe(200)
+})
+
+test('GET returns favorites list', async () => {
+  mockDb.all.mockResolvedValueOnce([{ id: 'a1', name: 'Agent', short_description: '' }])
+  const req = httpMocks.createRequest({ method: 'GET' })
+  const res = httpMocks.createResponse()
+
+  await listFavs(req, res)
+
+  expect(mockDb.all).toHaveBeenCalled()
+  const data = res._getJSONData()
+  expect(Array.isArray(data.agents)).toBe(true)
+})
+

--- a/__tests__/favoritesApi.test.ts
+++ b/__tests__/favoritesApi.test.ts
@@ -31,7 +31,7 @@ test('POST adds favorite', async () => {
     `INSERT OR IGNORE INTO user_favorite_agents(user_id, agent_id) VALUES(?, ?);`,
     [1, 'a1']
   )
-  expect(res._getStatusCode()).toBe(200)
+  expect(res._getStatusCode()).toBe(204)
 })
 
 test('DELETE removes favorite', async () => {
@@ -44,7 +44,7 @@ test('DELETE removes favorite', async () => {
     `DELETE FROM user_favorite_agents WHERE user_id = ? AND agent_id = ?;`,
     [1, 'a1']
   )
-  expect(res._getStatusCode()).toBe(200)
+  expect(res._getStatusCode()).toBe(204)
 })
 
 test('GET returns favorites list', async () => {

--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
-import HeartIcon from './HeartIcon';
-import { useFavorites } from '@/hooks/useFavorites';
+import FavoriteButton from './FavoriteButton';
 
 interface Props {
   id: string;
@@ -10,20 +9,13 @@ interface Props {
 }
 
 export default function AgentCard({ id, name, short_description }: Props) {
-  const { isFavorite, toggleFavorite } = useFavorites();
-  const agent = { id, name };
   return (
     <div className="agent-card">
       <h4 className="agent-title">
         <Link href={`/agents/${id}`}>{name}</Link>
       </h4>
       <p className="agent-description">{short_description}</p>
-      <button
-        className={`btn-heart ${isFavorite(id) ? 'active' : ''}`}
-        onClick={() => toggleFavorite(agent)}
-      >
-        <HeartIcon />
-      </button>
+      <FavoriteButton agentId={id} />
     </div>
   );
 }

--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
+import HeartIcon from './HeartIcon';
+import { useFavorites } from '@/hooks/useFavorites';
 
 interface Props {
   id: string;
@@ -8,12 +10,20 @@ interface Props {
 }
 
 export default function AgentCard({ id, name, short_description }: Props) {
+  const { isFavorite, toggleFavorite } = useFavorites();
+  const agent = { id, name };
   return (
     <div className="agent-card">
       <h4 className="agent-title">
         <Link href={`/agents/${id}`}>{name}</Link>
       </h4>
       <p className="agent-description">{short_description}</p>
+      <button
+        className={`btn-heart ${isFavorite(id) ? 'active' : ''}`}
+        onClick={() => toggleFavorite(agent)}
+      >
+        <HeartIcon />
+      </button>
     </div>
   );
 }

--- a/components/FavoriteButton.tsx
+++ b/components/FavoriteButton.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+import HeartIcon from './HeartIcon'
+
+interface Props {
+  agentId: string
+}
+
+export default function FavoriteButton({ agentId }: Props) {
+  const [favoriteIds, setFavoriteIds] = useState<string[]>([])
+
+  useEffect(() => {
+    fetch('/api/users/me/favorites', { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => setFavoriteIds((data.agents || []).map((a: any) => a.id)))
+      .catch(console.error)
+  }, [])
+
+  const isFav = favoriteIds.includes(agentId)
+
+  const toggle = async () => {
+    const method = isFav ? 'DELETE' : 'POST'
+    try {
+      await fetch(`/api/agents/${agentId}/favorite`, { method, credentials: 'include' })
+      setFavoriteIds(prev =>
+        isFav ? prev.filter(id => id !== agentId) : [...prev, agentId]
+      )
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  return (
+    <button className={`btn-heart ${isFav ? 'active' : ''}`} onClick={toggle}>
+      <HeartIcon filled={isFav} />
+    </button>
+  )
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
-import { useFavorites } from '@/hooks/useFavorites';
 
 interface SidebarProps {
   sidebarOpen: boolean;
@@ -24,7 +23,7 @@ export default function Sidebar({
   const [isFavoritesOpen, setFavoritesOpen] = useState(true);
   const [isRecentOpen, setRecentOpen] = useState(true);
   const [isMobile, setIsMobile] = useState(false);
-  const { favorites } = useFavorites();
+  const [favorites, setFavorites] = useState<any[]>([]);
 
   useEffect(() => {
     fetch('/api/categories')
@@ -32,6 +31,13 @@ export default function Sidebar({
       .then(setCategories)
       .catch(console.error);
   }, []);
+
+  useEffect(() => {
+    fetch('/api/users/me/favorites', { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => setFavorites(data.agents || []))
+      .catch(console.error)
+  }, [])
 
   useEffect(() => {
     console.log('Sidebar categories:', categories);
@@ -113,7 +119,7 @@ export default function Sidebar({
             </button>
             {isFavoritesOpen && (
               <ul className="sidebar-menu">
-                {favorites.map(a => (
+                {favorites.slice(0,5).map(a => (
                   <li key={a.id} className="sidebar-menu-item">
                     <Link href={`/agents/${a.id}`} className="sidebar-link">
                       <span className="link-text">{a.name}</span>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
+import { useFavorites } from '@/hooks/useFavorites';
 
 interface SidebarProps {
   sidebarOpen: boolean;
@@ -23,6 +24,7 @@ export default function Sidebar({
   const [isFavoritesOpen, setFavoritesOpen] = useState(true);
   const [isRecentOpen, setRecentOpen] = useState(true);
   const [isMobile, setIsMobile] = useState(false);
+  const { favorites } = useFavorites();
 
   useEffect(() => {
     fetch('/api/categories')
@@ -111,14 +113,16 @@ export default function Sidebar({
             </button>
             {isFavoritesOpen && (
               <ul className="sidebar-menu">
-                <li className="sidebar-menu-item">
-                  <Link href="#" className="sidebar-link">
-                    <span className="link-text">ИИ психолог</span>
-                  </Link>
-                </li>
-                <li className="sidebar-menu-item">
-                  <Link href="#" className="sidebar-link">
-                    <span className="link-text">Фитнес тренер</span>
+                {favorites.map(a => (
+                  <li key={a.id} className="sidebar-menu-item">
+                    <Link href={`/agents/${a.id}`} className="sidebar-link">
+                      <span className="link-text">{a.name}</span>
+                    </Link>
+                  </li>
+                ))}
+                <li className="sidebar-menu-item active">
+                  <Link href="/favorites" className="sidebar-link sidebar-link-all">
+                    <span className="link-text">Смотреть все</span>
                   </Link>
                 </li>
               </ul>

--- a/hooks/useFavorites.ts
+++ b/hooks/useFavorites.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect, useCallback } from 'react'
+
+export function useFavorites() {
+  const [favorites, setFavorites] = useState<{id:string,name:string}[]>([])
+  const load = useCallback(async () => {
+    const res = await fetch('/api/users/me/favorites', { credentials:'include' })
+    if (res.ok) setFavorites(await res.json())
+  }, [])
+  useEffect(() => { load() }, [load])
+  const isFavorite = useCallback((id:string) =>
+    favorites.some(f => f.id === id),
+    [favorites]
+  )
+  const toggleFavorite = useCallback(async (agent:{id:string,name:string}) => {
+    const method = isFavorite(agent.id) ? 'DELETE' : 'POST'
+    await fetch(`/api/agents/${agent.id}/favorite`, { method, credentials:'include' })
+    await load()
+  }, [isFavorite, load])
+  return { favorites, isFavorite, toggleFavorite, loadFavorites: load }
+}

--- a/hooks/useFavorites.ts
+++ b/hooks/useFavorites.ts
@@ -3,8 +3,11 @@ import { useState, useEffect, useCallback } from 'react'
 export function useFavorites() {
   const [favorites, setFavorites] = useState<{id:string,name:string}[]>([])
   const load = useCallback(async () => {
-    const res = await fetch('/api/users/me/favorites', { credentials:'include' })
-    if (res.ok) setFavorites(await res.json())
+    const res = await fetch('/api/users/me/favorites', { credentials: 'include' })
+    if (res.ok) {
+      const data = await res.json()
+      setFavorites(data.agents || [])
+    }
   }, [])
   useEffect(() => { load() }, [load])
   const isFavorite = useCallback((id:string) =>
@@ -13,7 +16,7 @@ export function useFavorites() {
   )
   const toggleFavorite = useCallback(async (agent:{id:string,name:string}) => {
     const method = isFavorite(agent.id) ? 'DELETE' : 'POST'
-    await fetch(`/api/agents/${agent.id}/favorite`, { method, credentials:'include' })
+    await fetch(`/api/agents/${agent.id}/favorite`, { method, credentials: 'include' })
     await load()
   }, [isFavorite, load])
   return { favorites, isFavorite, toggleFavorite, loadFavorites: load }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/?(*.)+(test).ts']
+  testMatch: ['**/?(*.)+(test).ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1'
+  }
 };

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,14 @@
+import { NextApiRequest } from 'next'
+import { openDb } from './db'
+
+export async function getSession(req: NextApiRequest) {
+  const cookies = req.headers.cookie || ''
+  const emailCookie = cookies.split(';').find(c => c.trim().startsWith('email='))
+  if (!emailCookie) return null
+  const email = decodeURIComponent(emailCookie.split('=')[1])
+  const db = await openDb()
+  const user = await db.get('SELECT id FROM users WHERE email = ?', email)
+  await db.close()
+  if (!user) return null
+  return { userId: user.id as number, email }
+}

--- a/migrations/20250715_add_favorites.sql
+++ b/migrations/20250715_add_favorites.sql
@@ -1,0 +1,12 @@
+BEGIN TRANSACTION;
+CREATE TABLE user_favorite_agents (
+  user_id    INTEGER    NOT NULL,
+  agent_id   TEXT       NOT NULL,
+  created_at TEXT       NOT NULL DEFAULT (datetime('now','localtime')),
+  PRIMARY KEY (user_id, agent_id),
+  FOREIGN KEY (user_id)  REFERENCES users  (id)   ON DELETE CASCADE,
+  FOREIGN KEY (agent_id) REFERENCES agents (id)   ON DELETE CASCADE
+);
+CREATE INDEX idx_fav_by_user  ON user_favorite_agents(user_id);
+CREATE INDEX idx_fav_by_agent ON user_favorite_agents(agent_id);
+COMMIT;

--- a/pages/agents/[id].tsx
+++ b/pages/agents/[id].tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import Sidebar from '@/components/Sidebar';
 import HamburgerIcon from '@/components/HamburgerIcon';
 import CloseIcon from '@/components/CloseIcon';
-import HeartIcon from '@/components/HeartIcon';
+import FavoriteButton from '@/components/FavoriteButton';
 
 
 // Функция для форматирования текста с абзацами
@@ -106,7 +106,6 @@ export default function AgentChat() {
   const [subscriptionStatus, setSubscriptionStatus] = useState<'active' | 'trial' | 'expired'>('trial');
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
-  const [isFavorite, setIsFavorite] = useState(false);
 
   useEffect(() => {
     setSidebarOpen(window.innerWidth > 768);
@@ -250,9 +249,6 @@ export default function AgentChat() {
     }
   };
 
-  const toggleFavorite = () => {
-    setIsFavorite(prev => !prev);
-  };
 
   return (
     <div className="chat-layout">
@@ -277,9 +273,7 @@ export default function AgentChat() {
             <button className="btn-clear-chat" onClick={handleClearChat}>
               Очистить чат
             </button>
-            <button className="btn-favorite" onClick={toggleFavorite}>
-              <HeartIcon filled={isFavorite} />
-            </button>
+            {typeof id === 'string' && <FavoriteButton agentId={id} />}
           </div>
           <div className="header__user" onClick={toggleUserMenu}>
             <span className="user-avatar">

--- a/pages/api/agents/[id]/favorite.ts
+++ b/pages/api/agents/[id]/favorite.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { getSession } from '@/lib/auth'
-import { openDb } from '@/lib/db'
+import { getSession } from '../../../../lib/auth'
+import { openDb } from '../../../../lib/db'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getSession(req)
@@ -11,11 +11,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (req.method === 'POST') {
     await db.run(
-      `INSERT OR IGNORE INTO user_favorite_agents(user_id, agent_id) VALUES(?,?);`,
+      `INSERT OR IGNORE INTO user_favorite_agents(user_id, agent_id) VALUES(?, ?);`,
       [user_id, agent_id]
     )
     await db.close()
-    return res.status(204).end()
+    return res.status(200).json({ success: true })
   }
   if (req.method === 'DELETE') {
     await db.run(
@@ -23,7 +23,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       [user_id, agent_id]
     )
     await db.close()
-    return res.status(204).end()
+    return res.status(200).json({ success: true })
   }
   await db.close()
   res.setHeader('Allow', ['POST','DELETE'])

--- a/pages/api/agents/[id]/favorite.ts
+++ b/pages/api/agents/[id]/favorite.ts
@@ -1,0 +1,31 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getSession } from '@/lib/auth'
+import { openDb } from '@/lib/db'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getSession(req)
+  if (!session) return res.status(401).end()
+  const user_id = session.userId
+  const agent_id = req.query.id as string
+  const db = await openDb()
+
+  if (req.method === 'POST') {
+    await db.run(
+      `INSERT OR IGNORE INTO user_favorite_agents(user_id, agent_id) VALUES(?,?);`,
+      [user_id, agent_id]
+    )
+    await db.close()
+    return res.status(204).end()
+  }
+  if (req.method === 'DELETE') {
+    await db.run(
+      `DELETE FROM user_favorite_agents WHERE user_id = ? AND agent_id = ?;`,
+      [user_id, agent_id]
+    )
+    await db.close()
+    return res.status(204).end()
+  }
+  await db.close()
+  res.setHeader('Allow', ['POST','DELETE'])
+  return res.status(405).end()
+}

--- a/pages/api/agents/[id]/favorite.ts
+++ b/pages/api/agents/[id]/favorite.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { getSession } from '../../../../lib/auth'
-import { openDb } from '../../../../lib/db'
+import { getSession } from '@/lib/auth'
+import { openDb } from '@/lib/db'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getSession(req)
@@ -15,7 +15,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       [user_id, agent_id]
     )
     await db.close()
-    return res.status(200).json({ success: true })
+    return res.status(204).end()
   }
   if (req.method === 'DELETE') {
     await db.run(
@@ -23,7 +23,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       [user_id, agent_id]
     )
     await db.close()
-    return res.status(200).json({ success: true })
+    return res.status(204).end()
   }
   await db.close()
   res.setHeader('Allow', ['POST','DELETE'])

--- a/pages/api/users/me/favorites.ts
+++ b/pages/api/users/me/favorites.ts
@@ -13,8 +13,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
        FROM agents a
        JOIN user_favorite_agents f ON f.agent_id = a.id
       WHERE f.user_id = ?
-      ORDER BY f.created_at DESC
-      LIMIT 5;`,
+      ORDER BY f.created_at DESC;`,
     [user_id]
   )
   await db.close()

--- a/pages/api/users/me/favorites.ts
+++ b/pages/api/users/me/favorites.ts
@@ -1,0 +1,22 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getSession } from '@/lib/auth'
+import { openDb } from '@/lib/db'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getSession(req)
+  if (!session) return res.status(401).end()
+  const user_id = session.userId
+  const db = await openDb()
+
+  const favorites = await db.all(
+    `SELECT a.id, a.name, a.short_description
+       FROM agents a
+       JOIN user_favorite_agents f ON f.agent_id = a.id
+      WHERE f.user_id = ?
+      ORDER BY f.created_at DESC
+      LIMIT 5;`,
+    [user_id]
+  )
+  await db.close()
+  return res.status(200).json(favorites)
+}

--- a/pages/api/users/me/favorites.ts
+++ b/pages/api/users/me/favorites.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { getSession } from '../../../../lib/auth'
-import { openDb } from '../../../../lib/db'
+import { getSession } from '@/lib/auth'
+import { openDb } from '@/lib/db'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getSession(req)

--- a/pages/api/users/me/favorites.ts
+++ b/pages/api/users/me/favorites.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { getSession } from '@/lib/auth'
-import { openDb } from '@/lib/db'
+import { getSession } from '../../../../lib/auth'
+import { openDb } from '../../../../lib/db'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getSession(req)
@@ -18,5 +18,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     [user_id]
   )
   await db.close()
-  return res.status(200).json(favorites)
+  return res.status(200).json({ agents: favorites })
 }

--- a/pages/favorites.tsx
+++ b/pages/favorites.tsx
@@ -1,0 +1,118 @@
+import Sidebar from '@/components/Sidebar'
+import HamburgerIcon from '@/components/HamburgerIcon'
+import CloseIcon from '@/components/CloseIcon'
+import Head from 'next/head'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+interface Agent {
+  id: string
+  name: string
+  short_description: string
+}
+
+export default function FavoritesPage() {
+  const [email, setEmail] = useState('')
+  const [subscriptionStatus, setSubscriptionStatus] = useState<'active'|'trial'|'expired'>('trial')
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [userMenuOpen, setUserMenuOpen] = useState(false)
+
+  const [favoriteAgents, setFavoriteAgents] = useState<Agent[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => { setSidebarOpen(window.innerWidth > 768) }, [])
+
+  useEffect(() => {
+    fetch('/api/me', { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => {
+        if (!data.email) {
+          window.location.href = '/auth/login'
+        } else {
+          setEmail(data.email)
+          setSubscriptionStatus(data.subscriptionStatus || 'expired')
+        }
+      })
+  }, [])
+
+  useEffect(() => {
+    fetch('/api/users/me/favorites', { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => {
+        setFavoriteAgents(data.agents || [])
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  const toggleSidebar = () => setSidebarOpen(!sidebarOpen)
+  const toggleUserMenu = () => setUserMenuOpen(!userMenuOpen)
+
+  const handleLogout = async () => {
+    try {
+      const res = await fetch('/api/logout', { credentials: 'include' })
+      if (res.ok) {
+        window.location.href = '/auth/login'
+      }
+    } catch (e) {
+      console.error('Ошибка при выходе:', e)
+    }
+  }
+
+  if (loading) return <div>Загрузка...</div>
+
+  return (
+    <div className="dashboard-layout">
+      <Head><title>Избранные агенты</title></Head>
+      <Sidebar
+        sidebarOpen={sidebarOpen}
+        toggleSidebar={toggleSidebar}
+        userEmail={email}
+        subscriptionStatus={subscriptionStatus}
+      />
+      <main className={`main-content ${sidebarOpen ? 'with-sidebar' : 'full-width'} p-6`}>
+        <header className="lk-header">
+          <button className="mobile-hamburger" onClick={toggleSidebar}>
+            {sidebarOpen ? <CloseIcon /> : <HamburgerIcon />}
+          </button>
+          <h1 className="header__title">Избранные агенты</h1>
+          <div className="header__user" onClick={toggleUserMenu}>
+            <span className="user-avatar">{email.charAt(0).toUpperCase()}</span>
+            {userMenuOpen && (
+              <ul className="dropdown-menu">
+                <li>
+                  <Link href="/profile">Профиль</Link>
+                </li>
+                <li>
+                  <button onClick={handleLogout}>Выйти</button>
+                </li>
+              </ul>
+            )}
+          </div>
+        </header>
+
+        {(subscriptionStatus === 'expired' || subscriptionStatus === 'trial') && (
+          <div className="access-warning">
+            <h3>🔓 Доступ ограничен</h3>
+            <p>Чтобы пользоваться всеми ИИ-помощниками без ограничений, оформите подписку.</p>
+          </div>
+        )}
+
+        {favoriteAgents.length === 0 ? (
+          <p>Нет избранных агентов.</p>
+        ) : (
+          <div className="agents-grid">
+            {favoriteAgents.map(agent => (
+              <Link key={agent.id} href={`/agents/${agent.id}`} className="agent-card-link">
+                <div className="agent-card">
+                  <h4 className="agent-title">{agent.name}</h4>
+                  <p className="agent-description">{agent.short_description}</p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add database migration for user favorites
- implement auth helper
- add API routes to toggle favorite agents and list favorites
- create React `useFavorites` hook
- integrate favorites into `AgentCard` and `Sidebar`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872356fcb38832899ba3e8cd4341c88