### PR TITLE
Add welcome popup on dashboard

### DIFF
--- a/__tests__/welcomePopup.test.tsx
+++ b/__tests__/welcomePopup.test.tsx
@@ -1,0 +1,30 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { WelcomePopup } from '../components/WelcomePopup';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('renders popup when flag missing', async () => {
+  const { findByText } = render(<WelcomePopup />);
+  expect(await findByText('Добро пожаловать!')).toBeInTheDocument();
+});
+
+test('does not render when dismissed', async () => {
+  localStorage.setItem('welcomePopupDismissed', 'true');
+  const { queryByText } = render(<WelcomePopup />);
+  await waitFor(() => {
+    expect(queryByText('Добро пожаловать!')).toBeNull();
+  });
+});
+
+test('saves flag when checkbox checked', async () => {
+  const { findByLabelText, findByText } = render(<WelcomePopup />);
+  const cb = await findByLabelText('Больше не показывать');
+  fireEvent.click(cb);
+  const closeBtn = await findByText('Закрыть');
+  fireEvent.click(closeBtn);
+  expect(localStorage.getItem('welcomePopupDismissed')).toBe('true');
+});

--- a/components/WelcomePopup.tsx
+++ b/components/WelcomePopup.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import Modal from '@/components/ui/Modal';
+
+/** Welcome popup shown on first dashboard visit */
+export function WelcomePopup() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [dontShow, setDontShow] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!localStorage.getItem('welcomePopupDismissed')) {
+      setIsOpen(true);
+    }
+  }, []);
+
+  const handleClose = () => {
+    if (dontShow) {
+      localStorage.setItem('welcomePopupDismissed', 'true');
+    }
+    setIsOpen(false);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <div className="p-6">
+        <h2 className="text-2xl font-bold mb-4">Добро пожаловать!</h2>
+        <p className="mb-6">Lorem ipsum dolor sit amet, consectetur adipiscing elit...</p>
+        <label className="flex items-center mb-4">
+          <input
+            type="checkbox"
+            checked={dontShow}
+            onChange={() => setDontShow(!dontShow)}
+            className="mr-2"
+          />
+          Больше не показывать
+        </label>
+        <button
+          onClick={handleClose}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Закрыть
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+/** Props for Modal component */
+export interface ModalProps {
+  /** Controls visibility */
+  isOpen: boolean;
+  /** Called when overlay or close action triggered */
+  onClose: () => void;
+  /** Modal content */
+  children: React.ReactNode;
+}
+
+/**
+ * Simple overlay modal.
+ */
+export default function Modal({ isOpen, onClose, children }: ModalProps) {
+  if (!isOpen) return null;
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal-content"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -5,6 +5,7 @@ import { useSidebarState } from '@/hooks/useSidebarState'
 import Sidebar from '@/components/Sidebar';
 import HamburgerIcon from '@/components/HamburgerIcon';
 import CloseIcon from '@/components/CloseIcon';
+import { WelcomePopup } from '@/components/WelcomePopup';
 
 
 interface Agent {
@@ -69,6 +70,8 @@ export default function Dashboard() {
   userEmail={email}
   subscriptionStatus={subscriptionStatus}
 />
+
+      <WelcomePopup />
 
       {/* Main Content */}
       <main className={`main-content ${sidebarOpen ? 'with-sidebar' : 'full-width'}`}>

--- a/styles/global.css
+++ b/styles/global.css
@@ -1911,3 +1911,28 @@ footer.site-footer {
   font-weight: bold;
 }
 
+
+/* Modal Styles */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background-color: white;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  width: 90%;
+}
+
+@media (min-width: 768px) {
+  .modal-content {
+    width: 60%;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add simple `Modal` component
- implement `WelcomePopup` with localStorage dismissal
- include popup on dashboard page
- style modal in global CSS
- test popup show/hide logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b471aa304832883bfc89c95beaac3