### PR TITLE
Add trial banner component

### DIFF
--- a/__tests__/trialBanner.test.ts
+++ b/__tests__/trialBanner.test.ts
@@ -1,0 +1,39 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TrialBanner } from '../components/TrialBanner';
+import { useUser } from '../hooks/useUser';
+
+jest.mock('../hooks/useUser');
+const mockedUseUser = useUser as jest.MockedFunction<typeof useUser>;
+
+describe('TrialBanner', () => {
+  it('renders when in trial', () => {
+    mockedUseUser.mockReturnValue({
+      user: { email: 'a', registeredAt: new Date().toISOString(), subscriptionStatus: 'trial' },
+      hasPlus: false,
+    });
+    const { container } = render(React.createElement(TrialBanner));
+    expect(container.textContent).toMatch(/Осталось/);
+  });
+
+  it('hides when has plus', () => {
+    mockedUseUser.mockReturnValue({
+      user: { email: 'a', registeredAt: new Date().toISOString(), subscriptionStatus: 'active' },
+      hasPlus: true,
+    });
+    const { container } = render(React.createElement(TrialBanner));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hides when trial expired', () => {
+    const past = new Date();
+    past.setDate(past.getDate() - 10);
+    mockedUseUser.mockReturnValue({
+      user: { email: 'a', registeredAt: past.toISOString(), subscriptionStatus: 'trial' },
+      hasPlus: false,
+    });
+    const { container } = render(React.createElement(TrialBanner));
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/components/TrialBanner.tsx
+++ b/components/TrialBanner.tsx
@@ -1,31 +1,31 @@
-// components/TrialBanner.tsx
-import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useUser } from '@/hooks/useUser';
 
-interface TrialBannerProps {
-  subscriptionStatus: 'trial' | 'active' | 'expired';
-}
+export function TrialBanner() {
+  const { user, hasPlus } = useUser();
+  if (hasPlus || !user?.registeredAt) return null;
 
-export default function TrialBanner({ subscriptionStatus }: TrialBannerProps) {
-  const router = useRouter();
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const hiddenPaths = ['/subscribe', '/subscribe/success', '/admin'];
-    const shouldShow =
-      subscriptionStatus === 'trial' &&
-      !hiddenPaths.some(path => router.pathname.startsWith(path));
-    setVisible(shouldShow);
-  }, [router.pathname, subscriptionStatus]);
-
-  if (!visible) return null;
+  const TRIAL_DAYS = 7;
+  const reg = new Date(user.registeredAt);
+  const diffMs = Date.now() - reg.getTime();
+  const daysSince = Math.floor(diffMs / 86400000);
+  const daysLeft = TRIAL_DAYS - daysSince;
+  if (daysLeft <= 0) return null;
 
   return (
-    <div className="bg-yellow-100 text-yellow-800 px-4 py-2 text-sm text-center border-b border-yellow-300 z-50 fixed top-0 left-0 w-full">
-      🧪 Пробный период. Чтобы пользоваться всеми ИИ-помощниками без ограничений,{' '}
-      <a href="/subscribe" className="underline font-medium hover:text-yellow-900 ml-1">
-        оформите подписку
-      </a>
+    <div className="fixed top-0 inset-x-0 bg-yellow-100 border-b border-yellow-300 z-50">
+      <div className="max-w-screen-xl mx-auto flex flex-col md:flex-row items-center justify-between px-4 py-3">
+        <div className="text-sm text-yellow-900">
+          Осталось <span className="font-semibold">{daysLeft}</span>{' '}
+          {daysLeft === 1 ? 'день' : daysLeft < 5 ? 'дня' : 'дней'}.{' '}
+          Чтобы пользоваться всеми ИИ-помощниками без ограничений, оформите подписку.
+        </div>
+        <Link href="/subscribe">
+          <a className="mt-2 md:mt-0 inline-block px-4 py-2 bg-yellow-600 text-white rounded hover:bg-yellow-700">
+            Оформить
+          </a>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+export interface UserData {
+  email: string;
+  registeredAt: string;
+  subscriptionStatus: 'trial' | 'active' | 'expired';
+}
+
+export function useUser() {
+  const [user, setUser] = useState<UserData | null>(null);
+  const [hasPlus, setHasPlus] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/me', { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => {
+        if (data?.email) {
+          setUser({
+            email: data.email,
+            registeredAt: data.registeredAt,
+            subscriptionStatus: data.subscriptionStatus,
+          });
+          setHasPlus(data.subscriptionStatus === 'active');
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  return { user, hasPlus };
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,8 @@ module.exports = {
   testMatch: ['**/?(*.)+(test).ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1'
+  },
+  globals: {
+    'ts-jest': { tsconfig: { jsx: 'react-jsx' } }
   }
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import type { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
 import Layout from '@/components/Layout';
 import AdminLayout from '@/components/AdminLayout';
+import { TrialBanner } from '@/components/TrialBanner';
 import '@/styles/global.css';
 import '@/styles/sidebar.css';
 
@@ -16,6 +17,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   if (isAdminPage) {
     return (
       <AdminLayout>
+        <TrialBanner />
         <Component {...pageProps} />
       </AdminLayout>
     );
@@ -23,6 +25,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   
   return (
     <Layout>
+      <TrialBanner />
       <Component {...pageProps} />
     </Layout>
   );

--- a/pages/api/me.ts
+++ b/pages/api/me.ts
@@ -24,7 +24,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
   if (hasPaid) {
     status = 'active';
-  } else if (diffInDays < 3) {
+  } else if (diffInDays < 7) {
     status = 'trial';
   }
 
@@ -32,7 +32,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     email: decodedEmail,
     registeredAt: registered.toISOString(),
     subscriptionStatus: status,
-    trialEndsIn: 3 - diffInDays,
+    trialEndsIn: 7 - diffInDays,
     isAdmin: decodedEmail === 'kcc-kem@ya.ru'
   });
 }

--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -146,13 +146,6 @@ useEffect(() => {
           </div>
         </header>
         <h1 className="section-title text-2xl font-bold mb-6">{categoryTitle}</h1>
-		
-		 {(subscriptionStatus === 'expired' || subscriptionStatus === 'trial') && (
-            <div className="access-warning">
-              <h3>🔓 Доступ ограничен</h3>
-              <p>Чтобы пользоваться всеми ИИ-помощниками без ограничений, оформите подписку.</p>
-            </div>
-          )}
 
         {categoryAgents.length === 0 && <p>Нет агентов в этой категории.</p>}
 

--- a/pages/categories/index.tsx
+++ b/pages/categories/index.tsx
@@ -158,12 +158,6 @@ export default function AllCategories() {
         </header>
 
         <h1 className="section-title text-2xl font-bold mb-4">Все категории</h1>
-        {subscriptionStatus !== 'active' && (
-          <div className="access-warning">
-            <h3>🔓 Доступ ограничен</h3>
-            <p>Чтобы пользоваться всеми ИИ-помощниками без ограничений, оформите подписку.</p>
-          </div>
-        )}
 
         <section className="categories-grid">
           {paginatedCategories.map(category => (

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -97,12 +97,6 @@ export default function Dashboard() {
         </header>
         <div className="content-header">
           <h2>Добро пожаловать!</h2>
-          {(subscriptionStatus === 'expired' || subscriptionStatus === 'trial') && (
-            <div className="access-warning">
-              <h3>🔓 Доступ ограничен</h3>
-              <p>Чтобы пользоваться всеми ИИ-помощниками без ограничений, оформите подписку.</p>
-            </div>
-          )}
           
           <Link href="/reset" className="reset-button">
             🔁 Сбросить подписку

--- a/pages/favorites.tsx
+++ b/pages/favorites.tsx
@@ -90,12 +90,6 @@ export default function FavoritesPage() {
           </div>
         </header>
 
-        {(subscriptionStatus === 'expired' || subscriptionStatus === 'trial') && (
-          <div className="access-warning">
-            <h3>🔓 Доступ ограничен</h3>
-            <p>Чтобы пользоваться всеми ИИ-помощниками без ограничений, оформите подписку.</p>
-          </div>
-        )}
 
         {favoriteAgents.length === 0 ? (
           <p>Нет избранных агентов.</p>


### PR DESCRIPTION
## Summary
- implement a `useUser` hook for registration and subscription info
- show new `TrialBanner` on all pages
- extend trial period to 7 days in API
- remove old access warnings from pages
- test banner behaviour with Jest
- configure ts-jest to compile JSX

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ce3d963048328a96876ca7499104c