### PR TITLE
fix: ensure assistant run sequencing

### DIFF
--- a/pages/api/admin/agents.ts
+++ b/pages/api/admin/agents.ts
@@ -42,6 +42,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       await db.close();
       return res.status(404).json({ message: 'Agent not found' });
     }
+
+    if (process.env.OPENAI_API_KEY) {
+      try {
+        const verifyRes = await fetch(`https://api.openai.com/v1/assistants/${id}`, {
+          headers: {
+            Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+            'OpenAI-Beta': 'assistants=v2',
+          },
+        });
+        if (!verifyRes.ok) {
+          console.error('Assistant verification failed', {
+            assistant_id: id,
+            status: verifyRes.status,
+            statusText: verifyRes.statusText,
+          });
+        }
+      } catch (e) {
+        console.error('Assistant verification error', id, e);
+      }
+    }
     await db.run(
       `UPDATE agents SET name=?, short_description=?, description=?, category_id=?, display_on_main=? WHERE id=?`,
       [

--- a/pages/api/assistants/[id]/test/index.ts
+++ b/pages/api/assistants/[id]/test/index.ts
@@ -1,0 +1,68 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ error: 'Missing id' });
+  }
+
+  try {
+    const threadRes = await fetch('https://api.openai.com/v1/threads', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        'OpenAI-Beta': 'assistants=v2',
+        'Content-Type': 'application/json',
+      },
+    });
+    const thread = await threadRes.json();
+
+    await fetch(`https://api.openai.com/v1/threads/${thread.id}/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        'OpenAI-Beta': 'assistants=v2',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ role: 'user', content: 'Привет' }),
+    });
+
+    const runRes = await fetch(`https://api.openai.com/v1/threads/${thread.id}/runs`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        'OpenAI-Beta': 'assistants=v2',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ assistant_id: id }),
+    });
+    const run = await runRes.json();
+
+    let status = run.status;
+    let lastError = run.last_error;
+    let attempts = 0;
+    while (status !== 'completed' && status !== 'failed' && attempts < 20) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const statusRes = await fetch(`https://api.openai.com/v1/threads/${thread.id}/runs/${run.id}`, {
+        headers: {
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          'OpenAI-Beta': 'assistants=v2',
+        },
+      });
+      const statusData = await statusRes.json();
+      status = statusData.status;
+      lastError = statusData.last_error;
+      attempts++;
+    }
+
+    return res.status(200).json({ status, last_error: lastError });
+  } catch (e: any) {
+    console.error('Assistant test error', { assistant_id: id, error: e.message });
+    return res
+      .status(500)
+      .json({ error: 'assistant_unavailable', details: e.message });
+  }
+}

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -70,15 +70,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     console.log('▶️ Run запущен:', { id: run.id, status: run.status });
 
     if (run.status === 'failed') {
-      console.error('❌ Run failed to start', {
+      console.error('OpenAI run.last_error:', run.last_error, {
         assistant_id,
         thread_id: threadId,
-        status: run.status,
-        last_error: run.last_error,
+        message,
       });
       return res.status(500).json({
         error: 'assistant_unavailable',
-        details: run.last_error?.message || 'run failed to start',
+        details: run.last_error,
       });
     }
 
@@ -104,15 +103,15 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     }
 
     if (status !== 'completed') {
-      console.error('❌ Run завершился ошибкой', {
+      console.error('OpenAI run.last_error:', lastError, {
         assistant_id,
         thread_id: threadId,
+        message,
         status,
-        last_error: lastError,
       });
       return res.status(500).json({
         error: 'assistant_unavailable',
-        details: lastError?.message || status,
+        details: lastError,
       });
     }
 

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -1,108 +1,128 @@
 // pages/api/chat.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const { message, assistant_id } = req.body;
-
-  if (!assistant_id) {
-    console.log('assistant_id отсутствует');
-  } else {
-    console.log('assistant_id:', assistant_id);
-  }
+  const { message, assistant_id, thread_id } = req.body;
 
   if (!message || !assistant_id) {
+    if (!assistant_id) console.log('assistant_id отсутствует');
     return res.status(400).json({ error: 'Missing message or assistant_id' });
   }
 
-  let thread: any = null
+  let threadId = thread_id;
   try {
-    // Создаём thread
-    const threadRes = await fetch('https://api.openai.com/v1/threads', {
+    console.log('Запрос к ассистенту', { assistant_id, thread_id, message });
+
+    if (!threadId) {
+      const threadRes = await fetch('https://api.openai.com/v1/threads', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          'OpenAI-Beta': 'assistants=v2',
+          'Content-Type': 'application/json',
+        },
+      });
+      const thread = await threadRes.json();
+      threadId = thread.id;
+      console.log('✅ Thread создан:', threadId);
+    } else {
+      console.log('ℹ️ Используем существующий thread:', threadId);
+    }
+
+    await fetch(`https://api.openai.com/v1/threads/${threadId}/messages`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
         'OpenAI-Beta': 'assistants=v2',
-        'Content-Type': 'application/json'
-      }
-    });
-
-    thread = await threadRes.json();
-    console.log('✅ Thread создан:', thread.id);
-
-    // Добавляем сообщение
-    await fetch(`https://api.openai.com/v1/threads/${thread.id}/messages`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-        'OpenAI-Beta': 'assistants=v2',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       },
       body: JSON.stringify({
         role: 'user',
-        content: message
-      })
+        content: message,
+      }),
     });
     console.log('✉️ Сообщение добавлено');
 
-    // Запускаем ассистента
-    const runRes = await fetch(`https://api.openai.com/v1/threads/${thread.id}/runs`, {
+    const runRes = await fetch(`https://api.openai.com/v1/threads/${threadId}/runs`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
         'OpenAI-Beta': 'assistants=v2',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ assistant_id })
+      body: JSON.stringify({ assistant_id }),
     });
+
+    if (!runRes.ok) {
+      console.error('❌ Run не запущен', runRes.status, runRes.statusText);
+      return res
+        .status(500)
+        .json({ error: 'assistant_unavailable', details: 'run failed to start' });
+    }
 
     const run = await runRes.json();
     console.log('▶️ Run запущен:', run);
 
-    // Ожидаем завершения run
     let status = 'queued';
     let attempts = 0;
     while (status !== 'completed' && attempts < 20) {
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      const statusRes = await fetch(`https://api.openai.com/v1/threads/${thread.id}/runs/${run.id}`, {
-        headers: {
-          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-          'OpenAI-Beta': 'assistants=v2'
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const statusRes = await fetch(
+        `https://api.openai.com/v1/threads/${threadId}/runs/${run.id}`,
+        {
+          headers: {
+            Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+            'OpenAI-Beta': 'assistants=v2',
+          },
         }
-      });
+      );
       const statusData = await statusRes.json();
       status = statusData.status;
       console.log(`⏳ Статус выполнения: ${status}`);
       attempts++;
     }
 
-    // Получаем сообщения после выполнения
-    const messagesRes = await fetch(`https://api.openai.com/v1/threads/${thread.id}/messages`, {
-      headers: {
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-        'OpenAI-Beta': 'assistants=v2'
+    const messagesRes = await fetch(
+      `https://api.openai.com/v1/threads/${threadId}/messages`,
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          'OpenAI-Beta': 'assistants=v2',
+        },
       }
-    });
+    );
 
     const messagesData = await messagesRes.json();
-    const lastAssistantMessage = messagesData.data.find((msg: any) => msg.role === 'assistant');
+    const lastAssistantMessage = messagesData.data.find(
+      (msg: any) => msg.role === 'assistant'
+    );
 
     if (!lastAssistantMessage) {
-      return res.status(200).json({ role: 'assistant', content: 'Ассистент не дал ответа.' });
+      return res.status(200).json({
+        role: 'assistant',
+        content: 'Ассистент не дал ответа.',
+        thread_id: threadId,
+      });
     }
 
-    return res.status(200).json({ role: 'assistant', content: lastAssistantMessage.content[0].text.value });
+    return res.status(200).json({
+      role: 'assistant',
+      content: lastAssistantMessage.content[0].text.value,
+      thread_id: threadId,
+    });
   } catch (error: any) {
     console.error('Ошибка OpenAI', error.response?.data || error.message || error, {
       assistant_id,
       message,
-      thread_id: thread?.id,
-    })
-    return res.status(500).json({ error: 'assistant_unavailable' })
+      thread_id: threadId,
+    });
+    return res
+      .status(500)
+      .json({ error: 'assistant_unavailable', details: error.message });
   }
 };
 

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -60,7 +60,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     });
 
     if (!runRes.ok) {
-      console.error('❌ Run не запущен', runRes.status, runRes.statusText);
+      console.error('❌ Run не запущен', {
+        assistant_id,
+        thread_id: threadId,
+        user_message: message,
+        status: runRes.status,
+        statusText: runRes.statusText,
+      });
       return res
         .status(500)
         .json({ error: 'assistant_unavailable', details: 'run failed to start' });
@@ -70,10 +76,12 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     console.log('▶️ Run запущен:', { id: run.id, status: run.status });
 
     if (run.status === 'failed') {
-      console.error('OpenAI run.last_error:', run.last_error, {
+      console.error('Assistant run failed', {
         assistant_id,
         thread_id: threadId,
-        message,
+        user_message: message,
+        run_status: run.status,
+        last_error: run.last_error,
       });
       return res.status(500).json({
         error: 'assistant_unavailable',
@@ -103,11 +111,12 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     }
 
     if (status !== 'completed') {
-      console.error('OpenAI run.last_error:', lastError, {
+      console.error('Assistant run failed', {
         assistant_id,
         thread_id: threadId,
-        message,
-        status,
+        user_message: message,
+        run_status: status,
+        last_error: lastError,
       });
       return res.status(500).json({
         error: 'assistant_unavailable',


### PR DESCRIPTION
## Summary
- ensure chat API creates threads when needed and propagates thread_id
- forward detailed run errors and return assistant replies
- persist thread id on client and show user-friendly error when assistant unavailable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c2ea504f88328a5c014712c3438c9