### PR TITLE
fix: load chat history after agent id ready

### DIFF
--- a/pages/agents/[slug].tsx
+++ b/pages/agents/[slug].tsx
@@ -177,7 +177,7 @@ export default function AgentChat({ slug }: PageProps) {
 
   // Загрузка истории сообщений из localStorage (только один раз)
   useEffect(() => {
-    if (router.isReady && !messagesLoaded) {
+    if (router.isReady && id && !messagesLoaded) {
       const saved = localStorage.getItem(`chat_${id}`);
       if (saved) {
         try {


### PR DESCRIPTION
## Summary
- ensure chat history is loaded only after agent identifier resolves

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ee9eecc548328a0622f698a7c2744