### PR TITLE
Fix subscription access checks and chat restrictions

### DIFF
--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -1,0 +1,9 @@
+export type SubscriptionStatus = 'trial' | 'active' | 'expired';
+
+export function isSubscriptionInvalid(
+  status: SubscriptionStatus,
+  subscriptionEnd?: string
+): boolean {
+  const isExpired = subscriptionEnd ? new Date(subscriptionEnd) < new Date() : false;
+  return status === 'expired' || status === 'trial' || (status === 'active' && isExpired);
+}

--- a/pages/agents/[slug].tsx
+++ b/pages/agents/[slug].tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useRef, ReactElement } from 'react';
 import { useSidebarState } from '@/hooks/useSidebarState';
 import Link from 'next/link';
 import React from 'react';
+import { isSubscriptionInvalid } from '@/lib/subscription';
 
 import { GetServerSideProps } from 'next';
 import { getAgentBySlug } from '@/lib/getAgentBySlug';
@@ -120,6 +121,7 @@ export default function AgentChat({ slug }: PageProps) {
   const [loading, setLoading] = useState(false);
   const [messagesLoaded, setMessagesLoaded] = useState(false);
   const [subscriptionStatus, setSubscriptionStatus] = useState<'active' | 'trial' | 'expired'>('trial');
+  const [subscriptionEnd, setSubscriptionEnd] = useState<string>('');
   const { sidebarOpen, toggleSidebar } = useSidebarState()
   const [userMenuOpen, setUserMenuOpen] = useState(false);
 
@@ -171,6 +173,7 @@ export default function AgentChat({ slug }: PageProps) {
         } else {
           setEmail(data.email);
           setSubscriptionStatus(data.subscriptionStatus || 'expired');
+          if (data.subscriptionEnd) setSubscriptionEnd(data.subscriptionEnd);
         }
       });
   }, []);
@@ -381,13 +384,13 @@ export default function AgentChat({ slug }: PageProps) {
               <div ref={messagesEndRef} />
             </div>
 
-            {subscriptionStatus === 'expired' ? (
+            {isSubscriptionInvalid(subscriptionStatus, subscriptionEnd) ? (
               <div className="chat-locked">
                 <div className="locked-message">
-                  <h3>🔒 Доступ к чату ограничен</h3>
-                  <p>Чтобы продолжить общение с ИИ-помощниками, оформите подписку.</p>
+                  <h3>🔒 Подписка истекла</h3>
+                  <p>Продлите подписку, чтобы продолжить общение с ИИ-помощниками.</p>
                   <Link href="/subscribe" className="upgrade-button">
-                    Оформить подписку
+                    Продлить подписку
                   </Link>
                 </div>
               </div>

--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -8,6 +8,7 @@ import { useSidebarState } from '@/hooks/useSidebarState'
 import Sidebar from '@/components/Sidebar';
 import HamburgerIcon from '@/components/HamburgerIcon';
 import CloseIcon from '@/components/CloseIcon';
+import { isSubscriptionInvalid } from '@/lib/subscription';
 
 export default function AgentPage() {
   const router = useRouter();
@@ -17,6 +18,7 @@ export default function AgentPage() {
 
   const [email, setEmail] = useState('');
   const [subscriptionStatus, setSubscriptionStatus] = useState<'active' | 'trial' | 'expired'>('trial');
+  const [subscriptionEnd, setSubscriptionEnd] = useState<string>('');
   const { sidebarOpen, toggleSidebar } = useSidebarState()
   const [userMenuOpen, setUserMenuOpen] = useState(false);
 
@@ -100,6 +102,7 @@ useEffect(() => {
         } else {
           setEmail(data.email);
           setSubscriptionStatus(data.subscriptionStatus || 'expired');
+          if (data.subscriptionEnd) setSubscriptionEnd(data.subscriptionEnd);
         }
       });
   }, []);
@@ -147,7 +150,7 @@ useEffect(() => {
         </header>
         <h1 className="section-title text-2xl font-bold mb-6">{categoryTitle}</h1>
 		
-		 {(subscriptionStatus === 'expired' || subscriptionStatus === 'trial') && (
+                 {isSubscriptionInvalid(subscriptionStatus, subscriptionEnd) && (
             <div className="access-warning">
               <h3>🔓 Доступ ограничен</h3>
               <p>Чтобы пользоваться всеми ИИ-помощниками без ограничений, оформите подписку.</p>

--- a/pages/categories/index.tsx
+++ b/pages/categories/index.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import Sidebar from '@/components/Sidebar';
 import HamburgerIcon from '@/components/HamburgerIcon';
 import CloseIcon from '@/components/CloseIcon';
+import { isSubscriptionInvalid } from '@/lib/subscription';
 import Pagination from '@/components/Pagination';
 
 interface Agent {
@@ -31,6 +32,7 @@ export default function AllCategories() {
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const [email, setEmail] = useState('');
   const [subscriptionStatus, setSubscriptionStatus] = useState<'trial' | 'active' | 'expired'>('trial');
+  const [subscriptionEnd, setSubscriptionEnd] = useState<string>('');
   const [categories, setCategories] = useState<CategoryWithAgents[]>([]);
   const [allAgents, setAllAgents] = useState<Agent[]>([]);
 
@@ -68,6 +70,7 @@ export default function AllCategories() {
         } else {
           setEmail(data.email);
           setSubscriptionStatus(data.subscriptionStatus || 'expired');
+          if (data.subscriptionEnd) setSubscriptionEnd(data.subscriptionEnd);
         }
       });
   }, []);
@@ -159,7 +162,7 @@ export default function AllCategories() {
         </header>
 
         <h1 className="section-title text-2xl font-bold mb-4">Все категории</h1>
-        {subscriptionStatus !== 'active' && (
+        {isSubscriptionInvalid(subscriptionStatus, subscriptionEnd) && (
           <div className="access-warning">
             <h3>🔓 Доступ ограничен</h3>
             <p>Чтобы пользоваться всеми ИИ-помощниками без ограничений, оформите подписку.</p>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useSidebarState } from '@/hooks/useSidebarState'
+import { isSubscriptionInvalid } from '@/lib/subscription'
 import Sidebar from '@/components/Sidebar';
 import HamburgerIcon from '@/components/HamburgerIcon';
 import CloseIcon from '@/components/CloseIcon';
@@ -21,6 +22,7 @@ interface Agent {
 export default function Dashboard() {
   const [email, setEmail] = useState('');
   const [subscriptionStatus, setSubscriptionStatus] = useState<'active' | 'trial' | 'expired'>('trial');
+  const [subscriptionEnd, setSubscriptionEnd] = useState<string>('');
   const { sidebarOpen, toggleSidebar } = useSidebarState()
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const [popularAgents, setPopularAgents] = useState<Agent[]>([]);
@@ -35,6 +37,7 @@ export default function Dashboard() {
         } else {
           setEmail(data.email);
           setSubscriptionStatus(data.subscriptionStatus || 'expired');
+          if (data.subscriptionEnd) setSubscriptionEnd(data.subscriptionEnd);
         }
       });
   }, []);
@@ -98,16 +101,12 @@ export default function Dashboard() {
         </header>
         <div className="content-header">
           <h2>Добро пожаловать!</h2>
-          {(subscriptionStatus === 'expired' || subscriptionStatus === 'trial') && (
+          {isSubscriptionInvalid(subscriptionStatus, subscriptionEnd) && (
             <div className="access-warning">
               <h3>🔓 Доступ ограничен</h3>
               <p>Чтобы пользоваться всеми ИИ-помощниками без ограничений, оформите подписку.</p>
             </div>
           )}
-          
-          <Link href="/reset" className="reset-button">
-            🔁 Сбросить подписку
-          </Link>
         </div>
 
         <section className="content-section">

--- a/pages/favorites.tsx
+++ b/pages/favorites.tsx
@@ -5,6 +5,7 @@ import Head from 'next/head'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useSidebarState } from '@/hooks/useSidebarState'
+import { isSubscriptionInvalid } from '@/lib/subscription'
 
 interface Agent {
   id: string
@@ -16,6 +17,7 @@ interface Agent {
 export default function FavoritesPage() {
   const [email, setEmail] = useState('')
   const [subscriptionStatus, setSubscriptionStatus] = useState<'active'|'trial'|'expired'>('trial')
+  const [subscriptionEnd, setSubscriptionEnd] = useState<string>('')
   const { sidebarOpen, toggleSidebar } = useSidebarState()
   const [userMenuOpen, setUserMenuOpen] = useState(false)
 
@@ -32,6 +34,7 @@ export default function FavoritesPage() {
         } else {
           setEmail(data.email)
           setSubscriptionStatus(data.subscriptionStatus || 'expired')
+          if (data.subscriptionEnd) setSubscriptionEnd(data.subscriptionEnd)
         }
       })
   }, [])
@@ -91,7 +94,7 @@ export default function FavoritesPage() {
           </div>
         </header>
 
-        {(subscriptionStatus === 'expired' || subscriptionStatus === 'trial') && (
+        {isSubscriptionInvalid(subscriptionStatus, subscriptionEnd) && (
           <div className="access-warning">
             <h3>🔓 Доступ ограничен</h3>
             <p>Чтобы пользоваться всеми ИИ-помощниками без ограничений, оформите подписку.</p>


### PR DESCRIPTION
## Summary
- centralize subscription validation helper
- show access banner only when subscription invalid and remove reset button
- block chat input when subscription is inactive

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f0f7198c083289680ba435c83eea7