### PR TITLE
Fix chat clearing and favorite state sync

### DIFF
--- a/__tests__/favoriteButton.test.tsx
+++ b/__tests__/favoriteButton.test.tsx
@@ -1,0 +1,10 @@
+/** @jest-environment jsdom */
+import { render } from '@testing-library/react'
+import FavoriteButton from '@/components/FavoriteButton'
+
+test('renders filled heart when agent is favorite', () => {
+  const { container } = render(<FavoriteButton agentId="1" initialIsFavorite={true} />)
+  const btn = container.querySelector('button.btn-heart')
+  expect(btn).not.toBeNull()
+  expect(btn!.classList.contains('active')).toBe(true)
+})

--- a/components/FavoriteButton.tsx
+++ b/components/FavoriteButton.tsx
@@ -10,6 +10,10 @@ export default function FavoriteButton({ agentId, initialIsFavorite = false }: P
   const [isFav, setIsFav] = useState(initialIsFavorite)
 
   useEffect(() => {
+    setIsFav(initialIsFavorite)
+  }, [initialIsFavorite])
+
+  useEffect(() => {
     if (initialIsFavorite) return
     fetch('/api/users/me/favorites', { credentials: 'include' })
       .then(res => res.json())

--- a/pages/agents/[slug].tsx
+++ b/pages/agents/[slug].tsx
@@ -297,7 +297,7 @@ export default function AgentChat({ slug }: PageProps) {
     console.log('🗑️ Очистка чата: запрошено');
     if (!id) return;
     try {
-      const res = await fetch(`/api/agents/${id}/clear`, {
+      const res = await fetch(`/api/agents/by-id/${id}/clear`, {
         method: 'POST',
         credentials: 'include',
       });

--- a/pages/api/agents/by-id/[id]/clear.ts
+++ b/pages/api/agents/by-id/[id]/clear.ts
@@ -1,0 +1,26 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getSession } from '@/lib/auth'
+import { openDb } from '@/lib/db'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).end()
+  }
+
+  const session = await getSession(req)
+  if (!session) return res.status(401).end()
+
+  const agentId = req.query.id as string
+  const db = await openDb()
+  try {
+    await db.run(
+      'DELETE FROM user_recent_chats WHERE user_id = ? AND chat_id = ?',
+      [session.userId, agentId]
+    )
+  } finally {
+    await db.close()
+  }
+
+  return res.status(204).end()
+}


### PR DESCRIPTION
## Summary
- fix chat clearing endpoint and add server route to delete recent chat record
- sync favorite button state with prop to render filled heart
- add unit test for favorite button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f2b6de3d083289521a82a89916626